### PR TITLE
docs: add STYLEGUIDE and simplify CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thank you for your interest in contributing to this project! This guide helps yo
 
 ### Prerequisites
 
-- **Python 3.11+** with type hints support
+- **Python 3.13+** with type hints support
 - **[uv](https://docs.astral.sh/uv/)** package manager (modern, fast Python package management)
 - **Docker** (for building container images)
 - **kubectl** and **kind** (required - application only runs in Kubernetes)
@@ -141,120 +141,9 @@ kubectl exec -it haproxy-template-ic -- socat - UNIX-CONNECT:/run/haproxy-templa
 
 ## Code Quality
 
-Our code quality standards ensure maintainable, secure, and robust code. All tools run automatically in CI and pre-commit hooks.
+For formatting, linting, typing, security scanning, and dependency hygiene, follow the repository Style Guide. It defines the authoritative rules and commands (Ruff formatter/linter, mypy, Bandit, Deptry) and how they’re enforced in CI and pre-commit.
 
-### 🎨 Code Formatting
-
-**Primary Tool**: `ruff` (fast, modern Python formatter)
-
-```bash
-# Format all Python files
-uv run ruff format
-
-# Check formatting without applying changes
-uv run ruff format --check
-
-# Format specific files
-uv run ruff format haproxy_template_ic/operator.py
-```
-
-**Configuration**: Defined in `pyproject.toml` with 88-character line length, following Black's style.
-
-### 🔍 Linting & Code Analysis
-
-**Primary Tool**: `ruff` (replaces flake8, isort, and more)
-
-```bash
-# Lint and auto-fix issues
-uv run ruff check --fix
-
-# Check without fixes (CI mode)
-uv run ruff check
-
-# Lint specific rules
-uv run ruff check --select E,W  # Only errors and warnings
-```
-
-**Ruff Features**:
-- ✅ Import sorting (replaces isort)
-- ✅ Code complexity analysis  
-- ✅ Best practice enforcement
-- ✅ Dead code detection
-- ✅ Performance anti-patterns
-
-### 🏷️ Type Checking
-
-**Primary Tool**: `mypy` (static type analysis)
-
-```bash
-# Check all production code (recommended)
-uv run mypy haproxy_template_ic/
-
-# Check specific modules
-uv run mypy haproxy_template_ic/operator.py haproxy_template_ic/config.py
-```
-
-**🎯 Type Checking Strategy**:
-- ✅ **Strict checking** for all production code
-- ✅ **Type stubs** for supported libraries (`click`, `PyYAML`, `requests`)  
-- ⚠️ **Selective ignoring** for libraries lacking type support (`kopf`, `kr8s`, `kubernetes`)
-- 🚫 **No global `--ignore-missing-imports`** - each library handled specifically
-- 📝 **100% type coverage** for production modules
-- 🚫 **Test files excluded** to focus on production code quality
-
-**Type Annotation Requirements**:
-- All functions must have return type annotations
-- All function parameters must have type annotations  
-- Use `typing.Optional` for nullable values
-- Prefer specific types over `Any` when possible
-
-### 🛡️ Security Scanning
-
-**Comprehensive security toolchain** runs automatically in CI:
-
-```bash
-# Security anti-pattern detection  
-uv run bandit -c pyproject.toml -r haproxy_template_ic/ --quiet
-
-# Dependency hygiene analysis
-uv run deptry .
-```
-
-**🔒 Security Tools**:
-
-| Tool | Purpose | What it catches |
-|------|---------|-----------------|
-| **Bandit** | Code security issues | SQL injection, hardcoded secrets, unsafe YAML loading |
-| **Deptry** | Dependency hygiene | Unused dependencies, missing imports |
-
-**Security Configuration**:
-- Test files excluded from security scans
-- Custom configuration in `pyproject.toml`
-- False positives handled with inline comments (`# nosec`)
-
-### ⚡ Development Commands
-
-**One-command quality check**:
-```bash
-# Run all quality checks (same as CI)
-uv run ruff format && \
-uv run ruff check --fix && \
-uv run mypy haproxy_template_ic/ && \
-uv run bandit -c pyproject.toml -r haproxy_template_ic/ --quiet && \
-uv run deptry .
-```
-
-**Pre-commit hooks** (automatic on commit):
-```bash
-# Install hooks (one-time setup)
-pre-commit install
-
-# Run hooks manually
-pre-commit run --all-files
-
-# Update hook versions
-pre-commit autoupdate
-```
+- See: [STYLEGUIDE.md](./STYLEGUIDE.md)
 
 ## Testing
 
@@ -505,14 +394,7 @@ Use conventional commits: `feat:`, `fix:`, `docs:`, `test:`, etc.
 
 ## Code Guidelines
 
-### 🎯 Code Quality Standards
-
-#### **Requirements**
-- ✅ PEP 8 compliance (enforced by ruff)
-- ✅ Type hints for all functions
-- ✅ Docstrings for public APIs  
-- ✅ Unit tests for new functions
-- ✅ Descriptive test names
+Please follow the conventions in [STYLEGUIDE.md](./STYLEGUIDE.md) for naming, typing, control flow, logging, async, documentation, tests, security, dependencies, and git/PR practices.
 
 ## Troubleshooting
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,0 +1,80 @@
+# Project Style Guide
+
+This repository uses modern Python tooling and enforces a consistent, readable codebase. Follow these rules when contributing.
+
+## Language and versions
+- Python: target >= 3.13 (see `pyproject.toml`).
+- Prefer standard library over third‑party when feasible.
+
+## Code formatting and linting
+- Formatter: Ruff formatter. Run `uv run ruff format`.
+- Linter: Ruff. Run `uv run ruff check`. Fix warnings unless explicitly justified.
+- Keep functions short and focused. Extract helpers when logic branches multiply.
+
+## Typing
+- Type‑annotate all public functions, classes, and module interfaces.
+- Internal helpers should be typed when complexity is non‑trivial.
+- Avoid `Any` and unsafe casts. Prefer precise, explicit types. See `tool.mypy` in `pyproject.toml`.
+
+## Naming
+- Descriptive names over abbreviations: `get_current_namespace`, not `get_ns`.
+- Functions: verbs or verb phrases. Variables: nouns or noun phrases.
+- Constants: UPPER_SNAKE_CASE; module constants at top of file.
+
+## Control flow
+- Use guard clauses to avoid deep nesting.
+- Raise exceptions early with descriptive messages.
+- Do not swallow exceptions; handle or propagate.
+
+## Errors and exceptions
+- Raise specific exceptions. Include actionable context in messages.
+- Avoid returning `None` for error states; prefer `Result`-like patterns or exceptions.
+
+## Logging
+- Use the `logging` module, not `print`.
+- Choose appropriate levels: `debug` for details, `info` for lifecycle, `warning` for recoverable, `error` for failures, `critical` for unrecoverable.
+
+## Async
+- Prefer `asyncio` for concurrent IO. Keep event loops single‑responsibility.
+- Avoid mixing blocking IO in async code. If needed, run in executors.
+
+## Configuration and templates
+- Keep config parsing strict (see `config_from_dict`). Validate user input.
+- Jinja templates should be small and pure; keep logic minimal.
+
+## Tests
+- Layout: `tests/` with `unit/`, `integration/`, `e2e/`.
+- Use `pytest` with markers:
+  - `-m "not slow"` for fast CI path
+  - `-m slow` for slower acceptance tests
+- Write deterministic tests; avoid real network or time dependencies unless in `e2e/`.
+- Use fixtures for shared setup and to keep tests isolated.
+
+## Security and dependencies
+- Keep dependencies minimal. Use `uv` for syncing.
+- Security scanning: `bandit`. Dependency hygiene: `deptry`.
+- Never hardcode secrets. Use GitHub secrets/CI env.
+
+## Docs and comments
+- Write docstrings for public APIs. Explain "why", not "what".
+- Keep comments concise; update them when code changes.
+
+## Git and PRs
+- Branch names: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `refactor/…`.
+- Commits: imperative mood, concise subject; body explains rationale.
+- All PRs must be green on CI and pass required checks.
+- Prefer squash merges; keep history clean and meaningful.
+
+## Make it easy to review
+- Smaller PRs are better. Include context in the PR description and a test plan.
+- Link related issues and discuss trade‑offs briefly.
+
+## Commands cheat‑sheet
+```
+uv sync --group dev
+uv run ruff format && uv run ruff check
+uv run mypy haproxy_template_ic/
+uv run pytest -q
+uv run bandit -c pyproject.toml -r haproxy_template_ic/
+uv run deptry .
+```


### PR DESCRIPTION
- Add `STYLEGUIDE.md` with conventions (formatting, linting, typing, tests, logging, async, security, deps, git/PRs).
- De-duplicate `CONTRIBUTING.md` and refer to the style guide.

CI should be unaffected.