### PR TITLE
ci(release): GHCR multi-arch builds on tags + artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,135 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-and-publish:
+    name: Build and publish Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: meta
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: '0.8.x'
+          activate-environment: true
+          enable-cache: true
+
+      - name: Generate artifacts (sdist/wheel)
+        run: |
+          uv build
+          ls -la dist
+
+      - name: Upload Python artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist-${{ steps.meta.outputs.tag }}
+          path: dist/*
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.meta.outputs.tag }}
+            type=raw,value=${{ steps.meta.outputs.version }}
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          file: ./Dockerfile
+          target: production
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          build-args: |
+            PYTHON_VERSION=3.13
+
+      - name: Export image tar (amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: false
+          platforms: linux/amd64
+          file: ./Dockerfile
+          target: production
+          tags: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.tag }}-amd64
+          outputs: type=tar,dest=/tmp/image-amd64.tar
+
+      - name: Export image tar (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: false
+          platforms: linux/arm64
+          file: ./Dockerfile
+          target: production
+          tags: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.tag }}-arm64
+          outputs: type=tar,dest=/tmp/image-arm64.tar
+
+      - name: Upload image tars
+        uses: actions/upload-artifact@v4
+        with:
+          name: images-${{ steps.meta.outputs.tag }}
+          path: |
+            /tmp/image-amd64.tar
+            /tmp/image-arm64.tar
+          compression-level: 0
+
+  publish-release:
+    name: Create GitHub Release
+    needs: build-and-publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          files: |
+            artifacts/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thank you for your interest in contributing to this project! This guide helps yo
 
 ### Prerequisites
 
-- **Python 3.11+** with type hints support
+- **Python 3.13+** with type hints support
 - **[uv](https://docs.astral.sh/uv/)** package manager (modern, fast Python package management)
 - **Docker** (for building container images)
 - **kubectl** and **kind** (required - application only runs in Kubernetes)
@@ -141,120 +141,9 @@ kubectl exec -it haproxy-template-ic -- socat - UNIX-CONNECT:/run/haproxy-templa
 
 ## Code Quality
 
-Our code quality standards ensure maintainable, secure, and robust code. All tools run automatically in CI and pre-commit hooks.
+For formatting, linting, typing, security scanning, and dependency hygiene, follow the repository Style Guide. It defines the authoritative rules and commands (Ruff formatter/linter, mypy, Bandit, Deptry) and how they’re enforced in CI and pre-commit.
 
-### 🎨 Code Formatting
-
-**Primary Tool**: `ruff` (fast, modern Python formatter)
-
-```bash
-# Format all Python files
-uv run ruff format
-
-# Check formatting without applying changes
-uv run ruff format --check
-
-# Format specific files
-uv run ruff format haproxy_template_ic/operator.py
-```
-
-**Configuration**: Defined in `pyproject.toml` with 88-character line length, following Black's style.
-
-### 🔍 Linting & Code Analysis
-
-**Primary Tool**: `ruff` (replaces flake8, isort, and more)
-
-```bash
-# Lint and auto-fix issues
-uv run ruff check --fix
-
-# Check without fixes (CI mode)
-uv run ruff check
-
-# Lint specific rules
-uv run ruff check --select E,W  # Only errors and warnings
-```
-
-**Ruff Features**:
-- ✅ Import sorting (replaces isort)
-- ✅ Code complexity analysis  
-- ✅ Best practice enforcement
-- ✅ Dead code detection
-- ✅ Performance anti-patterns
-
-### 🏷️ Type Checking
-
-**Primary Tool**: `mypy` (static type analysis)
-
-```bash
-# Check all production code (recommended)
-uv run mypy haproxy_template_ic/
-
-# Check specific modules
-uv run mypy haproxy_template_ic/operator.py haproxy_template_ic/config.py
-```
-
-**🎯 Type Checking Strategy**:
-- ✅ **Strict checking** for all production code
-- ✅ **Type stubs** for supported libraries (`click`, `PyYAML`, `requests`)  
-- ⚠️ **Selective ignoring** for libraries lacking type support (`kopf`, `kr8s`, `kubernetes`)
-- 🚫 **No global `--ignore-missing-imports`** - each library handled specifically
-- 📝 **100% type coverage** for production modules
-- 🚫 **Test files excluded** to focus on production code quality
-
-**Type Annotation Requirements**:
-- All functions must have return type annotations
-- All function parameters must have type annotations  
-- Use `typing.Optional` for nullable values
-- Prefer specific types over `Any` when possible
-
-### 🛡️ Security Scanning
-
-**Comprehensive security toolchain** runs automatically in CI:
-
-```bash
-# Security anti-pattern detection  
-uv run bandit -c pyproject.toml -r haproxy_template_ic/ --quiet
-
-# Dependency hygiene analysis
-uv run deptry .
-```
-
-**🔒 Security Tools**:
-
-| Tool | Purpose | What it catches |
-|------|---------|-----------------|
-| **Bandit** | Code security issues | SQL injection, hardcoded secrets, unsafe YAML loading |
-| **Deptry** | Dependency hygiene | Unused dependencies, missing imports |
-
-**Security Configuration**:
-- Test files excluded from security scans
-- Custom configuration in `pyproject.toml`
-- False positives handled with inline comments (`# nosec`)
-
-### ⚡ Development Commands
-
-**One-command quality check**:
-```bash
-# Run all quality checks (same as CI)
-uv run ruff format && \
-uv run ruff check --fix && \
-uv run mypy haproxy_template_ic/ && \
-uv run bandit -c pyproject.toml -r haproxy_template_ic/ --quiet && \
-uv run deptry .
-```
-
-**Pre-commit hooks** (automatic on commit):
-```bash
-# Install hooks (one-time setup)
-pre-commit install
-
-# Run hooks manually
-pre-commit run --all-files
-
-# Update hook versions
-pre-commit autoupdate
-```
+- See: [STYLEGUIDE.md](./STYLEGUIDE.md)
 
 ## Testing
 
@@ -505,14 +394,7 @@ Use conventional commits: `feat:`, `fix:`, `docs:`, `test:`, etc.
 
 ## Code Guidelines
 
-### 🎯 Code Quality Standards
-
-#### **Requirements**
-- ✅ PEP 8 compliance (enforced by ruff)
-- ✅ Type hints for all functions
-- ✅ Docstrings for public APIs  
-- ✅ Unit tests for new functions
-- ✅ Descriptive test names
+Please follow the conventions in [STYLEGUIDE.md](./STYLEGUIDE.md) for naming, typing, control flow, logging, async, documentation, tests, security, dependencies, and git/PR practices.
 
 ## Troubleshooting
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,0 +1,80 @@
+# Project Style Guide
+
+This repository uses modern Python tooling and enforces a consistent, readable codebase. Follow these rules when contributing.
+
+## Language and versions
+- Python: target >= 3.13 (see `pyproject.toml`).
+- Prefer standard library over third‑party when feasible.
+
+## Code formatting and linting
+- Formatter: Ruff formatter. Run `uv run ruff format`.
+- Linter: Ruff. Run `uv run ruff check`. Fix warnings unless explicitly justified.
+- Keep functions short and focused. Extract helpers when logic branches multiply.
+
+## Typing
+- Type‑annotate all public functions, classes, and module interfaces.
+- Internal helpers should be typed when complexity is non‑trivial.
+- Avoid `Any` and unsafe casts. Prefer precise, explicit types. See `tool.mypy` in `pyproject.toml`.
+
+## Naming
+- Descriptive names over abbreviations: `get_current_namespace`, not `get_ns`.
+- Functions: verbs or verb phrases. Variables: nouns or noun phrases.
+- Constants: UPPER_SNAKE_CASE; module constants at top of file.
+
+## Control flow
+- Use guard clauses to avoid deep nesting.
+- Raise exceptions early with descriptive messages.
+- Do not swallow exceptions; handle or propagate.
+
+## Errors and exceptions
+- Raise specific exceptions. Include actionable context in messages.
+- Avoid returning `None` for error states; prefer `Result`-like patterns or exceptions.
+
+## Logging
+- Use the `logging` module, not `print`.
+- Choose appropriate levels: `debug` for details, `info` for lifecycle, `warning` for recoverable, `error` for failures, `critical` for unrecoverable.
+
+## Async
+- Prefer `asyncio` for concurrent IO. Keep event loops single‑responsibility.
+- Avoid mixing blocking IO in async code. If needed, run in executors.
+
+## Configuration and templates
+- Keep config parsing strict (see `config_from_dict`). Validate user input.
+- Jinja templates should be small and pure; keep logic minimal.
+
+## Tests
+- Layout: `tests/` with `unit/`, `integration/`, `e2e/`.
+- Use `pytest` with markers:
+  - `-m "not slow"` for fast CI path
+  - `-m slow` for slower acceptance tests
+- Write deterministic tests; avoid real network or time dependencies unless in `e2e/`.
+- Use fixtures for shared setup and to keep tests isolated.
+
+## Security and dependencies
+- Keep dependencies minimal. Use `uv` for syncing.
+- Security scanning: `bandit`. Dependency hygiene: `deptry`.
+- Never hardcode secrets. Use GitHub secrets/CI env.
+
+## Docs and comments
+- Write docstrings for public APIs. Explain "why", not "what".
+- Keep comments concise; update them when code changes.
+
+## Git and PRs
+- Branch names: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `refactor/…`.
+- Commits: imperative mood, concise subject; body explains rationale.
+- All PRs must be green on CI and pass required checks.
+- Prefer squash merges; keep history clean and meaningful.
+
+## Make it easy to review
+- Smaller PRs are better. Include context in the PR description and a test plan.
+- Link related issues and discuss trade‑offs briefly.
+
+## Commands cheat‑sheet
+```
+uv sync --group dev
+uv run ruff format && uv run ruff check
+uv run mypy haproxy_template_ic/
+uv run pytest -q
+uv run bandit -c pyproject.toml -r haproxy_template_ic/
+uv run deptry .
+```

--- a/deploy/base/clusterrole.yaml
+++ b/deploy/base/clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: haproxy-template-ic
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "configmaps", "events", "namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]

--- a/deploy/base/clusterrolebinding.yaml
+++ b/deploy/base/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: haproxy-template-ic
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: haproxy-template-ic
+subjects:
+  - kind: ServiceAccount
+    name: haproxy-template-ic
+    namespace: haproxy-template-ic

--- a/deploy/base/configmap.yaml
+++ b/deploy/base/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: haproxy-template-ic-config
+  namespace: haproxy-template-ic
+data:
+  config: |
+    pod_selector: "app=haproxy"
+    watch_resources:
+      ingresses:
+        group: networking.k8s.io
+        kind: Ingress
+    maps:
+      /etc/haproxy/maps/backend.map:
+        path: /etc/haproxy/maps/backend.map
+        template: |
+          {% for svc in resources.get('services', []) %}
+          server {{ svc.name }} {{ svc.ip }}:{{ svc.port }}
+          {% endfor %}

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: haproxy-template-ic
+  namespace: haproxy-template-ic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: haproxy-template-ic
+  template:
+    metadata:
+      labels:
+        app: haproxy-template-ic
+    spec:
+      serviceAccountName: haproxy-template-ic
+      containers:
+        - name: controller
+          image: ghcr.io/OWNER/REPO:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CONFIGMAP_NAME
+              value: haproxy-template-ic-config
+            - name: VERBOSE
+              value: "1"
+          ports:
+            - name: healthz
+              containerPort: 8080
+          volumeMounts:
+            - name: run
+              mountPath: /run/haproxy-template-ic
+      volumes:
+        - name: run
+          emptyDir: {}

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: haproxy-template-ic
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/deploy/base/namespace.yaml
+++ b/deploy/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: haproxy-template-ic

--- a/deploy/base/service.yaml
+++ b/deploy/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: haproxy-template-ic
+  namespace: haproxy-template-ic
+spec:
+  selector:
+    app: haproxy-template-ic
+  ports:
+    - name: http
+      port: 8080
+      targetPort: healthz

--- a/deploy/base/serviceaccount.yaml
+++ b/deploy/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: haproxy-template-ic
+  namespace: haproxy-template-ic

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: haproxy-template-ic
+resources:
+  - ../../base
+images:
+  - name: ghcr.io/OWNER/REPO
+    newName: ghcr.io/phihos/haproxy-template-ingress-controller
+    newTag: latest
+patches:
+  - target:
+      kind: Deployment
+      name: haproxy-template-ic
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env/0/value
+        value: haproxy-template-ic-config


### PR DESCRIPTION
- Builds and pushes `ghcr.io/${{ github.repository }}` images on `v*.*.*` tags (amd64+arm64)
- Uploads Python `dist/` (sdist/wheel) and per-arch image tars as artifacts
- Creates a GitHub Release and attaches artifacts

Notes:
- Uses Dockerfile `production` target
- Tags: `latest`, the tag (e.g. `v0.1.0`), and the semver without `v` (e.g. `0.1.0`)