### PR TITLE
feat(helm): add Helm chart with RBAC, config, probes, and test hook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,135 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-and-publish:
+    name: Build and publish Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: meta
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: '0.8.x'
+          activate-environment: true
+          enable-cache: true
+
+      - name: Generate artifacts (sdist/wheel)
+        run: |
+          uv build
+          ls -la dist
+
+      - name: Upload Python artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist-${{ steps.meta.outputs.tag }}
+          path: dist/*
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.meta.outputs.tag }}
+            type=raw,value=${{ steps.meta.outputs.version }}
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          file: ./Dockerfile
+          target: production
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          build-args: |
+            PYTHON_VERSION=3.13
+
+      - name: Export image tar (amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: false
+          platforms: linux/amd64
+          file: ./Dockerfile
+          target: production
+          tags: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.tag }}-amd64
+          outputs: type=tar,dest=/tmp/image-amd64.tar
+
+      - name: Export image tar (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: false
+          platforms: linux/arm64
+          file: ./Dockerfile
+          target: production
+          tags: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.tag }}-arm64
+          outputs: type=tar,dest=/tmp/image-arm64.tar
+
+      - name: Upload image tars
+        uses: actions/upload-artifact@v4
+        with:
+          name: images-${{ steps.meta.outputs.tag }}
+          path: |
+            /tmp/image-amd64.tar
+            /tmp/image-arm64.tar
+          compression-level: 0
+
+  publish-release:
+    name: Create GitHub Release
+    needs: build-and-publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          files: |
+            artifacts/**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,10 @@ repos:
     hooks:
       # Check YAML files have valid syntax.
       - id: check-yaml
+        exclude: ^charts/.*/templates/.*\.ya?ml$
       # Sort YAML files.
       - id: sort-simple-yaml
+        exclude: ^charts/.*/templates/.*\.ya?ml$
       # Ensure YAML files end with a newline.
       - id: end-of-file-fixer
         types: [yaml]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thank you for your interest in contributing to this project! This guide helps yo
 
 ### Prerequisites
 
-- **Python 3.11+** with type hints support
+- **Python 3.13+** with type hints support
 - **[uv](https://docs.astral.sh/uv/)** package manager (modern, fast Python package management)
 - **Docker** (for building container images)
 - **kubectl** and **kind** (required - application only runs in Kubernetes)
@@ -141,120 +141,9 @@ kubectl exec -it haproxy-template-ic -- socat - UNIX-CONNECT:/run/haproxy-templa
 
 ## Code Quality
 
-Our code quality standards ensure maintainable, secure, and robust code. All tools run automatically in CI and pre-commit hooks.
+For formatting, linting, typing, security scanning, and dependency hygiene, follow the repository Style Guide. It defines the authoritative rules and commands (Ruff formatter/linter, mypy, Bandit, Deptry) and how they’re enforced in CI and pre-commit.
 
-### 🎨 Code Formatting
-
-**Primary Tool**: `ruff` (fast, modern Python formatter)
-
-```bash
-# Format all Python files
-uv run ruff format
-
-# Check formatting without applying changes
-uv run ruff format --check
-
-# Format specific files
-uv run ruff format haproxy_template_ic/operator.py
-```
-
-**Configuration**: Defined in `pyproject.toml` with 88-character line length, following Black's style.
-
-### 🔍 Linting & Code Analysis
-
-**Primary Tool**: `ruff` (replaces flake8, isort, and more)
-
-```bash
-# Lint and auto-fix issues
-uv run ruff check --fix
-
-# Check without fixes (CI mode)
-uv run ruff check
-
-# Lint specific rules
-uv run ruff check --select E,W  # Only errors and warnings
-```
-
-**Ruff Features**:
-- ✅ Import sorting (replaces isort)
-- ✅ Code complexity analysis  
-- ✅ Best practice enforcement
-- ✅ Dead code detection
-- ✅ Performance anti-patterns
-
-### 🏷️ Type Checking
-
-**Primary Tool**: `mypy` (static type analysis)
-
-```bash
-# Check all production code (recommended)
-uv run mypy haproxy_template_ic/
-
-# Check specific modules
-uv run mypy haproxy_template_ic/operator.py haproxy_template_ic/config.py
-```
-
-**🎯 Type Checking Strategy**:
-- ✅ **Strict checking** for all production code
-- ✅ **Type stubs** for supported libraries (`click`, `PyYAML`, `requests`)  
-- ⚠️ **Selective ignoring** for libraries lacking type support (`kopf`, `kr8s`, `kubernetes`)
-- 🚫 **No global `--ignore-missing-imports`** - each library handled specifically
-- 📝 **100% type coverage** for production modules
-- 🚫 **Test files excluded** to focus on production code quality
-
-**Type Annotation Requirements**:
-- All functions must have return type annotations
-- All function parameters must have type annotations  
-- Use `typing.Optional` for nullable values
-- Prefer specific types over `Any` when possible
-
-### 🛡️ Security Scanning
-
-**Comprehensive security toolchain** runs automatically in CI:
-
-```bash
-# Security anti-pattern detection  
-uv run bandit -c pyproject.toml -r haproxy_template_ic/ --quiet
-
-# Dependency hygiene analysis
-uv run deptry .
-```
-
-**🔒 Security Tools**:
-
-| Tool | Purpose | What it catches |
-|------|---------|-----------------|
-| **Bandit** | Code security issues | SQL injection, hardcoded secrets, unsafe YAML loading |
-| **Deptry** | Dependency hygiene | Unused dependencies, missing imports |
-
-**Security Configuration**:
-- Test files excluded from security scans
-- Custom configuration in `pyproject.toml`
-- False positives handled with inline comments (`# nosec`)
-
-### ⚡ Development Commands
-
-**One-command quality check**:
-```bash
-# Run all quality checks (same as CI)
-uv run ruff format && \
-uv run ruff check --fix && \
-uv run mypy haproxy_template_ic/ && \
-uv run bandit -c pyproject.toml -r haproxy_template_ic/ --quiet && \
-uv run deptry .
-```
-
-**Pre-commit hooks** (automatic on commit):
-```bash
-# Install hooks (one-time setup)
-pre-commit install
-
-# Run hooks manually
-pre-commit run --all-files
-
-# Update hook versions
-pre-commit autoupdate
-```
+- See: [STYLEGUIDE.md](./STYLEGUIDE.md)
 
 ## Testing
 
@@ -505,14 +394,7 @@ Use conventional commits: `feat:`, `fix:`, `docs:`, `test:`, etc.
 
 ## Code Guidelines
 
-### 🎯 Code Quality Standards
-
-#### **Requirements**
-- ✅ PEP 8 compliance (enforced by ruff)
-- ✅ Type hints for all functions
-- ✅ Docstrings for public APIs  
-- ✅ Unit tests for new functions
-- ✅ Descriptive test names
+Please follow the conventions in [STYLEGUIDE.md](./STYLEGUIDE.md) for naming, typing, control flow, logging, async, documentation, tests, security, dependencies, and git/PR practices.
 
 ## Troubleshooting
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,0 +1,80 @@
+# Project Style Guide
+
+This repository uses modern Python tooling and enforces a consistent, readable codebase. Follow these rules when contributing.
+
+## Language and versions
+- Python: target >= 3.13 (see `pyproject.toml`).
+- Prefer standard library over third‑party when feasible.
+
+## Code formatting and linting
+- Formatter: Ruff formatter. Run `uv run ruff format`.
+- Linter: Ruff. Run `uv run ruff check`. Fix warnings unless explicitly justified.
+- Keep functions short and focused. Extract helpers when logic branches multiply.
+
+## Typing
+- Type‑annotate all public functions, classes, and module interfaces.
+- Internal helpers should be typed when complexity is non‑trivial.
+- Avoid `Any` and unsafe casts. Prefer precise, explicit types. See `tool.mypy` in `pyproject.toml`.
+
+## Naming
+- Descriptive names over abbreviations: `get_current_namespace`, not `get_ns`.
+- Functions: verbs or verb phrases. Variables: nouns or noun phrases.
+- Constants: UPPER_SNAKE_CASE; module constants at top of file.
+
+## Control flow
+- Use guard clauses to avoid deep nesting.
+- Raise exceptions early with descriptive messages.
+- Do not swallow exceptions; handle or propagate.
+
+## Errors and exceptions
+- Raise specific exceptions. Include actionable context in messages.
+- Avoid returning `None` for error states; prefer `Result`-like patterns or exceptions.
+
+## Logging
+- Use the `logging` module, not `print`.
+- Choose appropriate levels: `debug` for details, `info` for lifecycle, `warning` for recoverable, `error` for failures, `critical` for unrecoverable.
+
+## Async
+- Prefer `asyncio` for concurrent IO. Keep event loops single‑responsibility.
+- Avoid mixing blocking IO in async code. If needed, run in executors.
+
+## Configuration and templates
+- Keep config parsing strict (see `config_from_dict`). Validate user input.
+- Jinja templates should be small and pure; keep logic minimal.
+
+## Tests
+- Layout: `tests/` with `unit/`, `integration/`, `e2e/`.
+- Use `pytest` with markers:
+  - `-m "not slow"` for fast CI path
+  - `-m slow` for slower acceptance tests
+- Write deterministic tests; avoid real network or time dependencies unless in `e2e/`.
+- Use fixtures for shared setup and to keep tests isolated.
+
+## Security and dependencies
+- Keep dependencies minimal. Use `uv` for syncing.
+- Security scanning: `bandit`. Dependency hygiene: `deptry`.
+- Never hardcode secrets. Use GitHub secrets/CI env.
+
+## Docs and comments
+- Write docstrings for public APIs. Explain "why", not "what".
+- Keep comments concise; update them when code changes.
+
+## Git and PRs
+- Branch names: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `refactor/…`.
+- Commits: imperative mood, concise subject; body explains rationale.
+- All PRs must be green on CI and pass required checks.
+- Prefer squash merges; keep history clean and meaningful.
+
+## Make it easy to review
+- Smaller PRs are better. Include context in the PR description and a test plan.
+- Link related issues and discuss trade‑offs briefly.
+
+## Commands cheat‑sheet
+```
+uv sync --group dev
+uv run ruff format && uv run ruff check
+uv run mypy haproxy_template_ic/
+uv run pytest -q
+uv run bandit -c pyproject.toml -r haproxy_template_ic/
+uv run deptry .
+```

--- a/charts/haproxy-template-ic/.helmignore
+++ b/charts/haproxy-template-ic/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/haproxy-template-ic/Chart.yaml
+++ b/charts/haproxy-template-ic/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: haproxy-template-ic
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/haproxy-template-ic/templates/NOTES.txt
+++ b/charts/haproxy-template-ic/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "haproxy-template-ic.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "haproxy-template-ic.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "haproxy-template-ic.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "haproxy-template-ic.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/haproxy-template-ic/templates/_helpers.tpl
+++ b/charts/haproxy-template-ic/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "haproxy-template-ic.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "haproxy-template-ic.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "haproxy-template-ic.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "haproxy-template-ic.labels" -}}
+helm.sh/chart: {{ include "haproxy-template-ic.chart" . }}
+{{ include "haproxy-template-ic.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "haproxy-template-ic.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "haproxy-template-ic.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "haproxy-template-ic.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "haproxy-template-ic.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/haproxy-template-ic/templates/clusterrole.yaml
+++ b/charts/haproxy-template-ic/templates/clusterrole.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "haproxy-template-ic.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "configmaps", "events", "namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/charts/haproxy-template-ic/templates/clusterrolebinding.yaml
+++ b/charts/haproxy-template-ic/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "haproxy-template-ic.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "haproxy-template-ic.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "haproxy-template-ic.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/haproxy-template-ic/templates/configmap.yaml
+++ b/charts/haproxy-template-ic/templates/configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.controller.configmapName }}
+  labels:
+    {{- include "haproxy-template-ic.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+data:
+  config: |
+    pod_selector: "app=haproxy"
+    watch_resources:
+      ingresses:
+        group: networking.k8s.io
+        kind: Ingress
+    maps:
+      /etc/haproxy/maps/backend.map:
+        path: /etc/haproxy/maps/backend.map
+        template: |
+          {% for svc in resources.get('services', []) %}
+          server {{ "{{" }} svc.name {{ "}}" }} {{ "{{" }} svc.ip {{ "}}" }}:{{ "{{" }} svc.port {{ "}}" }}
+          {% endfor %}

--- a/charts/haproxy-template-ic/templates/deployment.yaml
+++ b/charts/haproxy-template-ic/templates/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "haproxy-template-ic.fullname" . }}
+  labels:
+    {{- include "haproxy-template-ic.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "haproxy-template-ic.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "haproxy-template-ic.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "haproxy-template-ic.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: healthz
+              containerPort: {{ .Values.controller.healthzPort }}
+              protocol: TCP
+          env:
+            - name: CONFIGMAP_NAME
+              value: {{ .Values.controller.configmapName | quote }}
+            - name: HEALTHZ_PORT
+              value: {{ .Values.controller.healthzPort | quote }}
+            - name: VERBOSE
+              value: {{ .Values.controller.verbose | quote }}
+            - name: SOCKET_PATH
+              value: {{ .Values.controller.socketPath | quote }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/haproxy-template-ic/templates/hpa.yaml
+++ b/charts/haproxy-template-ic/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "haproxy-template-ic.fullname" . }}
+  labels:
+    {{- include "haproxy-template-ic.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "haproxy-template-ic.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/haproxy-template-ic/templates/ingress.yaml
+++ b/charts/haproxy-template-ic/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "haproxy-template-ic.fullname" . }}
+  labels:
+    {{- include "haproxy-template-ic.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "haproxy-template-ic.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/haproxy-template-ic/templates/service.yaml
+++ b/charts/haproxy-template-ic/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "haproxy-template-ic.fullname" . }}
+  labels:
+    {{- include "haproxy-template-ic.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: healthz
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "haproxy-template-ic.selectorLabels" . | nindent 4 }}

--- a/charts/haproxy-template-ic/templates/serviceaccount.yaml
+++ b/charts/haproxy-template-ic/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "haproxy-template-ic.serviceAccountName" . }}
+  labels:
+    {{- include "haproxy-template-ic.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/haproxy-template-ic/templates/tests/test-connection.yaml
+++ b/charts/haproxy-template-ic/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "haproxy-template-ic.fullname" . }}-test-connection"
+  labels:
+    {{- include "haproxy-template-ic.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['-qO-', 'http://{{ include "haproxy-template-ic.fullname" . }}:{{ .Values.service.port }}/healthz']
+  restartPolicy: Never

--- a/charts/haproxy-template-ic/tests/values-minimal.yaml
+++ b/charts/haproxy-template-ic/tests/values-minimal.yaml
@@ -1,0 +1,9 @@
+image:
+  repository: ghcr.io/phihos/haproxy-template-ingress-controller
+  tag: latest
+controller:
+  configmapName: haproxy-template-ic-config
+  healthzPort: 8080
+service:
+  type: ClusterIP
+  port: 8080

--- a/charts/haproxy-template-ic/values.yaml
+++ b/charts/haproxy-template-ic/values.yaml
@@ -1,0 +1,135 @@
+# Default values for haproxy-template-ic.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: ghcr.io/phihos/haproxy-template-ingress-controller
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# Controller configuration
+controller:
+  configmapName: haproxy-template-ic-config
+  healthzPort: 8080
+  verbose: 1
+  socketPath: /run/haproxy-template-ic/management.sock
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 8080
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+# Health probes
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: healthz
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: healthz
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# RBAC
+rbac:
+  create: true

--- a/deploy/base/clusterrole.yaml
+++ b/deploy/base/clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: haproxy-template-ic
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "configmaps", "events", "namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]

--- a/deploy/base/clusterrolebinding.yaml
+++ b/deploy/base/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: haproxy-template-ic
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: haproxy-template-ic
+subjects:
+  - kind: ServiceAccount
+    name: haproxy-template-ic
+    namespace: haproxy-template-ic

--- a/deploy/base/configmap.yaml
+++ b/deploy/base/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: haproxy-template-ic-config
+  namespace: haproxy-template-ic
+data:
+  config: |
+    pod_selector: "app=haproxy"
+    watch_resources:
+      ingresses:
+        group: networking.k8s.io
+        kind: Ingress
+    maps:
+      /etc/haproxy/maps/backend.map:
+        path: /etc/haproxy/maps/backend.map
+        template: |
+          {% for svc in resources.get('services', []) %}
+          server {{ svc.name }} {{ svc.ip }}:{{ svc.port }}
+          {% endfor %}

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: haproxy-template-ic
+  namespace: haproxy-template-ic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: haproxy-template-ic
+  template:
+    metadata:
+      labels:
+        app: haproxy-template-ic
+    spec:
+      serviceAccountName: haproxy-template-ic
+      containers:
+        - name: controller
+          image: ghcr.io/OWNER/REPO:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CONFIGMAP_NAME
+              value: haproxy-template-ic-config
+            - name: VERBOSE
+              value: "1"
+          ports:
+            - name: healthz
+              containerPort: 8080
+          volumeMounts:
+            - name: run
+              mountPath: /run/haproxy-template-ic
+      volumes:
+        - name: run
+          emptyDir: {}

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: haproxy-template-ic
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/deploy/base/namespace.yaml
+++ b/deploy/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: haproxy-template-ic

--- a/deploy/base/service.yaml
+++ b/deploy/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: haproxy-template-ic
+  namespace: haproxy-template-ic
+spec:
+  selector:
+    app: haproxy-template-ic
+  ports:
+    - name: http
+      port: 8080
+      targetPort: healthz

--- a/deploy/base/serviceaccount.yaml
+++ b/deploy/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: haproxy-template-ic
+  namespace: haproxy-template-ic

--- a/deploy/overlays/dev/kustomization.yaml
+++ b/deploy/overlays/dev/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: haproxy-template-ic
+resources:
+  - ../../base
+images:
+  - name: ghcr.io/OWNER/REPO
+    newName: ghcr.io/phihos/haproxy-template-ingress-controller
+    newTag: latest
+patches:
+  - target:
+      kind: Deployment
+      name: haproxy-template-ic
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env/0/value
+        value: haproxy-template-ic-config


### PR DESCRIPTION
- New chart `charts/haproxy-template-ic` (RBAC, ServiceAccount, Deployment, Service, ConfigMap example)
- Health endpoint wiring and env vars for controller config
- Helm test hook exercising `/healthz`
- Pre-commit excludes Helm templates from YAML syntax hook

Tested with `helm lint` and `helm template`.