### PR TITLE
docs: add PR title conventions to development workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,8 @@ Follow the style guide in `STYLEGUIDE.md`:
 
 **Standard Process**: Feature branch → Plan/implement → Test (`uv run pytest -n auto`) → Quality checks → Commit → PR → Review → Merge
 
+**PR Titles**: Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format for PR titles as they become the first line of squashed merge commits: `<type>: <description>`
+
 **Kind Development**:
 1. Setup: `bash ./scripts/start-dev-env.sh`, build/load image
 2. Test: Run unit/integration/e2e tests with debugging options


### PR DESCRIPTION
Updates CLAUDE.md to specify that PR titles must follow conventional commits format since they become the first line of squashed merge commits on GitHub.

This ensures consistent commit history and enables automated tooling based on commit message format.