### PR TITLE
Simplify structured logging with radical code reduction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Remove dependency: `uv remove <package>`
 
 ### Testing
-- **All tests (recommended)**: `uv run pytest -n auto` - parallel execution, up to 8 minutes
+- **Development workflow**: First run unit tests `uv run pytest -m "not integration and not acceptance"`, fix all failures, then run all tests
+- **All tests (recommended)**: `timeout 480 uv run pytest -n auto` - parallel execution, up to 8 minutes (use 480s timeout)
 - **Unit tests**: `uv run pytest -m "not integration and not acceptance"`
 - **Integration tests**: `uv run pytest -m integration`
 - **E2E tests**: `uv run pytest -m acceptance`

--- a/haproxy_template_ic/operator.py
+++ b/haproxy_template_ic/operator.py
@@ -18,12 +18,7 @@ from kopf._core.engines.indexing import OperatorIndexers
 from kopf._core.intents.registries import SmartOperatorRegistry
 from kr8s.objects import ConfigMap
 
-from haproxy_template_ic.structured_logging import (
-    get_structured_logger,
-    operation_context,
-    component_context_manager,
-    resource_context_manager,
-)
+from haproxy_template_ic.structured_logging import logging_context
 from haproxy_template_ic.tracing import (
     trace_async_function,
     trace_template_render,
@@ -53,8 +48,9 @@ from haproxy_template_ic.management_socket import run_management_socket_server
 from haproxy_template_ic.metrics import get_metrics_collector
 import os
 from kubernetes import config
+import structlog
 
-logger = get_structured_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def get_current_namespace() -> str:
@@ -170,39 +166,34 @@ async def handle_configmap_change(
     **kwargs: Any,
 ) -> None:
     """Handle ConfigMap change events."""
-    with operation_context() as operation_id:
-        with component_context_manager("operator"):
-            with resource_context_manager(
-                resource_type="ConfigMap",
-                resource_namespace=event["object"].get("metadata", {}).get("namespace"),
-                resource_name=name,
-            ):
-                structured_logger = get_structured_logger(__name__)
-                structured_logger.info(
-                    f"Kubernetes {type}",
-                    kubernetes_event=type,
-                    resource_type="ConfigMap",
-                    resource_namespace=event["object"]
-                    .get("metadata", {})
-                    .get("namespace", "unknown"),
-                    resource_name=name,
-                    operation_id=operation_id,
-                )
+    with logging_context(
+        operation_id=None,  # Auto-generate operation ID
+        component="operator",
+        resource_type="ConfigMap",
+        resource_namespace=event["object"].get("metadata", {}).get("namespace"),
+        resource_name=name,
+    ) as operation_id:
+        structured_logger = structlog.get_logger(__name__)
+        structured_logger.info(
+            f"Kubernetes {type}",
+            kubernetes_event=type,
+            operation_id=operation_id,
+        )
 
-                new_config = await load_config_from_configmap(event["object"])
+        new_config = await load_config_from_configmap(event["object"])
 
-                # Compare model dictionaries to avoid issues with compiled templates and object identity
-                # Use serialization mode to exclude non-serializable fields like compiled templates
-                old_dict = memo.config.model_dump(mode="serialization")
-                new_dict = new_config.model_dump(mode="serialization")
+        # Compare model dictionaries to avoid issues with compiled templates and object identity
+        # Use serialization mode to exclude non-serializable fields like compiled templates
+        old_dict = memo.config.model_dump(mode="serialization")
+        new_dict = new_config.model_dump(mode="serialization")
 
-                if old_dict != new_dict:
-                    diff = DeepDiff(old_dict, new_dict, verbose_level=2)
-                    diff_str = str(diff)[:500]
-                    structured_logger.info(
-                        "🔄 Config has changed: reloading", config_diff=diff_str
-                    )
-                    trigger_reload(memo)
+        if old_dict != new_dict:
+            diff = DeepDiff(old_dict, new_dict, verbose_level=2)
+            diff_str = str(diff)[:500]
+            structured_logger.info(
+                "🔄 Config has changed: reloading", config_diff=diff_str
+            )
+            trigger_reload(memo)
 
 
 async def update_resource_index(
@@ -224,12 +215,11 @@ async def update_resource_index(
 )
 async def render_haproxy_templates(memo: Any, **kwargs: Any) -> None:
     """Render all HAProxy templates with current context data."""
-    with operation_context() as operation_id:
-        with component_context_manager("operator"):
-            logger.debug("Rendering HAProxy templates", operation_id=operation_id)
-            metrics = get_metrics_collector()
+    with logging_context(operation_id=None, component="operator") as operation_id:
+        logger.debug("Rendering HAProxy templates", operation_id=operation_id)
+        metrics = get_metrics_collector()
 
-            # Collect all indices from registered watch resources
+        # Collect all indices from registered watch resources
     indices: Dict[str, Dict[str, Any]] = {}
     for resource_id, watch_config in memo.config.watched_resources.items():
         try:

--- a/haproxy_template_ic/structured_logging.py
+++ b/haproxy_template_ic/structured_logging.py
@@ -7,7 +7,6 @@ using the industry-standard structlog library.
 """
 
 import logging
-import time
 from contextlib import contextmanager
 from typing import Any, Optional, Iterator, List
 from uuid import uuid4
@@ -19,119 +18,32 @@ import structlog.contextvars
 # LogContext dataclass removed - using contextvars directly for context management
 
 
-# Pre-compiled format string for better performance
-_BASE_MESSAGE_FORMAT = "{timestamp} - {logger} - {level} - {event}"
-
-
-def custom_logfmt_renderer(_, __, event_dict):
-    """Custom renderer that appends context fields in logfmt format to traditional log messages."""
-    # Extract standard log fields
-    timestamp = event_dict.pop("timestamp", "")
-    level = event_dict.pop("level", "")
-    logger = event_dict.pop("logger", "")
-    event = event_dict.pop("event", "")
-
-    # Format the base message using pre-compiled format string
-    base_message = _BASE_MESSAGE_FORMAT.format(
-        timestamp=timestamp, logger=logger, level=level, event=event
-    )
-
-    # Format remaining context fields as logfmt and append
-    if event_dict:
-        logfmt_parts = []
-        for key, value in event_dict.items():
-            # Quote values that contain spaces, tabs, newlines, or special characters
-            if isinstance(value, str) and any(
-                char in value for char in (" ", "\t", "\n", "\r", '"', "=", "\\")
-            ):
-                # Escape special characters in the value
-                escaped_value = (
-                    value.replace("\\", "\\\\")
-                    .replace('"', '\\"')
-                    .replace("\n", "\\n")
-                    .replace("\r", "\\r")
-                    .replace("\t", "\\t")
-                )
-                logfmt_parts.append(f'{key}="{escaped_value}"')
-            else:
-                logfmt_parts.append(f"{key}={value}")
-
-        logfmt_string = " ".join(logfmt_parts)
-        return f"{base_message} {logfmt_string}"
-
-    return base_message
-
-
-def custom_timestamp_processor(_, __, event_dict):
-    """Custom timestamp processor that formats timestamps to match original format."""
-    # Capture time once to ensure thread safety
-    current_time = time.time()
-    # Format timestamp with milliseconds from the same time capture
-    timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(current_time))
-    # Add milliseconds from the same time capture
-    timestamp += f",{int((current_time % 1) * 1000):03d}"
-    event_dict["timestamp"] = timestamp
-    return event_dict
-
-
 @contextmanager
-def operation_context(operation_id: Optional[str] = None) -> Iterator[str]:
-    """Context manager for operation correlation."""
-    if operation_id is None:
-        operation_id = str(uuid4())[:8]  # Short UUID for readability
+def logging_context(**kwargs: Any) -> Iterator[Optional[str]]:
+    """Universal context manager for structured logging.
 
-    structlog.contextvars.bind_contextvars(operation_id=operation_id)
-    try:
-        yield operation_id
-    finally:
-        structlog.contextvars.unbind_contextvars("operation_id")
+    Supports all context types:
+    - operation_id (generates UUID if None)
+    - component
+    - resource_type, resource_namespace, resource_name
+    - Any additional fields
+    """
+    # Handle special case for operation_id generation
+    if "operation_id" in kwargs and kwargs["operation_id"] is None:
+        kwargs["operation_id"] = str(uuid4())[:8]
 
-
-@contextmanager
-def component_context_manager(component: str) -> Iterator[None]:
-    """Context manager for component identification."""
-    structlog.contextvars.bind_contextvars(component=component)
-    try:
-        yield
-    finally:
-        structlog.contextvars.unbind_contextvars("component")
-
-
-@contextmanager
-def resource_context_manager(
-    resource_type: Optional[str] = None,
-    resource_namespace: Optional[str] = None,
-    resource_name: Optional[str] = None,
-    **extra_fields: Any,
-) -> Iterator[None]:
-    """Context manager for resource identification."""
-    context = {}
-    if resource_type:
-        context["resource_type"] = resource_type
-    if resource_namespace:
-        context["resource_namespace"] = resource_namespace
-    if resource_name:
-        context["resource_name"] = resource_name
-
-    # Add any additional context fields
-    context.update(extra_fields)
-
-    # Track which keys we actually bind to ensure proper cleanup
+    # Remove None/empty values to avoid cluttering logs
+    context = {k: v for k, v in kwargs.items() if v is not None}
     bound_keys = list(context.keys())
 
     if bound_keys:
         structlog.contextvars.bind_contextvars(**context)
     try:
-        yield
+        # Return operation_id for backward compatibility with operation_context
+        yield context.get("operation_id")
     finally:
-        # Unbind only the context fields we actually set
         if bound_keys:
             structlog.contextvars.unbind_contextvars(*bound_keys)
-
-
-def get_structured_logger(name: str):
-    """Get a structured logger for the given name."""
-    return structlog.get_logger(name)
 
 
 def setup_structured_logging(verbose_level: int, use_json: bool = False) -> None:
@@ -162,8 +74,15 @@ def setup_structured_logging(verbose_level: int, use_json: bool = False) -> None
             ]
         )
     else:
-        # Add custom timestamp and logfmt renderer for traditional format
-        processors.extend([custom_timestamp_processor, custom_logfmt_renderer])
+        # Use structlog's built-in processors for traditional format
+        processors.extend(
+            [
+                structlog.processors.TimeStamper(fmt="iso"),
+                structlog.processors.KeyValueRenderer(
+                    key_order=["timestamp", "level", "logger"]
+                ),
+            ]
+        )
 
     # Configure structlog
     structlog.configure(

--- a/haproxy_template_ic/tracing.py
+++ b/haproxy_template_ic/tracing.py
@@ -23,9 +23,9 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.semconv.resource import ResourceAttributes
 from opentelemetry.trace import Status, StatusCode
 
-from haproxy_template_ic.structured_logging import get_structured_logger
+import structlog
 
-logger = get_structured_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 F = TypeVar("F", bound=Callable[..., Any])
 AsyncF = TypeVar("AsyncF", bound=Callable[..., Awaitable[Any]])

--- a/tests/unit/test_structured_logging.py
+++ b/tests/unit/test_structured_logging.py
@@ -11,140 +11,11 @@ from io import StringIO
 from unittest.mock import patch
 
 
+import structlog
 from haproxy_template_ic.structured_logging import (
-    get_structured_logger,
     setup_structured_logging,
-    operation_context,
-    component_context_manager,
-    resource_context_manager,
-    custom_logfmt_renderer,
-    custom_timestamp_processor,
+    logging_context,
 )
-
-
-class TestCustomProcessors:
-    """Test cases for custom structlog processors."""
-
-    def test_custom_timestamp_processor(self):
-        """Test custom timestamp processor formats correctly."""
-        event_dict = {"event": "test message"}
-        result = custom_timestamp_processor(None, None, event_dict)
-
-        assert "timestamp" in result
-        # Check timestamp format (YYYY-MM-DD HH:MM:SS,mmm)
-        timestamp = result["timestamp"]
-        assert len(timestamp) == 23  # Expected length for the format
-        assert "," in timestamp  # Should contain comma separator for milliseconds
-
-    def test_custom_logfmt_renderer(self):
-        """Test custom logfmt renderer formats correctly."""
-        event_dict = {
-            "timestamp": "2025-01-01 12:00:00,000",
-            "level": "INFO",
-            "logger": "test.module",
-            "event": "Test message",
-            "operation_id": "test-op-123",
-            "component": "test-component",
-        }
-
-        result = custom_logfmt_renderer(None, None, event_dict)
-
-        # Should start with traditional format
-        assert result.startswith(
-            "2025-01-01 12:00:00,000 - test.module - INFO - Test message"
-        )
-        # Should end with logfmt context
-        assert "operation_id=test-op-123" in result
-        assert "component=test-component" in result
-
-    def test_custom_logfmt_renderer_with_quotes(self):
-        """Test custom logfmt renderer handles values with spaces and quotes."""
-        event_dict = {
-            "timestamp": "2025-01-01 12:00:00,000",
-            "level": "INFO",
-            "logger": "test.module",
-            "event": "Test message",
-            "config_diff": "{'key': 'value with spaces'}",
-            "simple": "no_spaces",
-        }
-
-        result = custom_logfmt_renderer(None, None, event_dict)
-
-        # Should quote values with spaces
-        assert "config_diff=\"{'key': 'value with spaces'}\"" in result
-        # Should not quote simple values
-        assert "simple=no_spaces" in result
-
-    def test_custom_logfmt_renderer_special_characters(self):
-        """Test custom logfmt renderer handles special characters correctly."""
-        event_dict = {
-            "timestamp": "2025-01-01 12:00:00,000",
-            "level": "INFO",
-            "logger": "test.module",
-            "event": "Test message",
-            "multiline": "line1\nline2\nline3",
-            "with_tabs": "col1\tcol2\tcol3",
-            "with_carriage": "data\rmore_data",
-            "with_quotes": 'value with "quotes" inside',
-            "with_backslashes": "path\\to\\file",
-            "normal": "simple_value",
-        }
-
-        result = custom_logfmt_renderer(None, None, event_dict)
-
-        # Should properly escape newlines
-        assert 'multiline="line1\\nline2\\nline3"' in result
-        # Should properly escape tabs
-        assert 'with_tabs="col1\\tcol2\\tcol3"' in result
-        # Should properly escape carriage returns
-        assert 'with_carriage="data\\rmore_data"' in result
-        # Should properly escape quotes
-        assert 'with_quotes="value with \\"quotes\\" inside"' in result
-        # Should properly escape backslashes
-        assert 'with_backslashes="path\\\\to\\\\file"' in result
-        # Should not quote normal values
-        assert "normal=simple_value" in result
-
-    def test_custom_timestamp_processor_thread_safety(self):
-        """Test timestamp processor captures time consistently."""
-        import time
-
-        # Mock time.time and time.gmtime to verify they're called consistently
-        original_time = time.time
-        original_gmtime = time.gmtime
-
-        mock_time_value = 1640995200.122  # Fixed timestamp with milliseconds
-        mock_time_calls = []
-        mock_gmtime_calls = []
-
-        def mock_time():
-            mock_time_calls.append(mock_time_value)
-            return mock_time_value
-
-        def mock_gmtime(timestamp):
-            mock_gmtime_calls.append(timestamp)
-            return original_gmtime(timestamp)
-
-        try:
-            time.time = mock_time
-            time.gmtime = mock_gmtime
-
-            event_dict = {"event": "test message"}
-            result = custom_timestamp_processor(None, None, event_dict)
-
-            # Should have called time.time() once
-            assert len(mock_time_calls) == 1
-            # Should have called time.gmtime() once with the same timestamp
-            assert len(mock_gmtime_calls) == 1
-            assert mock_gmtime_calls[0] == mock_time_value
-
-            # Should have correct timestamp format with milliseconds
-            assert "timestamp" in result
-            assert result["timestamp"] == "2022-01-01 00:00:00,121"
-
-        finally:
-            time.time = original_time
-            time.gmtime = original_gmtime
 
 
 class TestStructuredLogger:
@@ -155,7 +26,7 @@ class TestStructuredLogger:
         # Setup structlog first
         setup_structured_logging(verbose_level=1, use_json=False)
 
-        logger = get_structured_logger("test")
+        logger = structlog.get_logger("test")
         # Verify logger has required logging methods
         assert hasattr(logger, "debug")
         assert hasattr(logger, "info")
@@ -168,7 +39,7 @@ class TestStructuredLogger:
         # Setup structlog first
         setup_structured_logging(verbose_level=1, use_json=False)
 
-        logger = get_structured_logger("test")
+        logger = structlog.get_logger("test")
 
         # Should not raise exceptions
         logger.debug("Debug message")
@@ -188,9 +59,9 @@ class TestStructuredLogger:
         root_logger = logging.getLogger()
         root_logger.handlers = [handler]
 
-        structured_logger = get_structured_logger("test_context")
+        structured_logger = structlog.get_logger("test_context")
 
-        with operation_context("test-operation"):
+        with logging_context(operation_id="test-operation"):
             structured_logger.info("Test message", custom_field="test_value")
 
         output = stream.getvalue().strip()
@@ -203,15 +74,15 @@ class TestStructuredLogger:
 class TestContextManagers:
     """Test cases for context manager functionality."""
 
-    def test_operation_context_auto_generation(self):
+    def test_logging_context_auto_generation(self):
         """Test automatic operation ID generation."""
-        with operation_context() as op_id:
+        with logging_context(operation_id=None) as op_id:
             assert isinstance(op_id, str)
             assert len(op_id) == 8  # Short UUID
 
-    def test_operation_context_explicit_id(self):
+    def test_logging_context_explicit_id(self):
         """Test explicit operation ID setting."""
-        with operation_context("custom-op-id") as op_id:
+        with logging_context(operation_id="custom-op-id") as op_id:
             assert op_id == "custom-op-id"
 
     def test_nested_contexts(self):
@@ -225,12 +96,12 @@ class TestContextManagers:
         root_logger = logging.getLogger()
         root_logger.handlers = [handler]
 
-        structured_logger = get_structured_logger("test_nested")
+        structured_logger = structlog.get_logger("test_nested")
 
-        with operation_context("outer-op"):
-            with component_context_manager("component-a"):
-                with resource_context_manager(resource_type="Service"):
-                    structured_logger.info("Nested message")
+        with logging_context(
+            operation_id="outer-op", component="component-a", resource_type="Service"
+        ):
+            structured_logger.info("Nested message")
 
         output = stream.getvalue().strip()
         if output:  # Only parse if we got output
@@ -251,11 +122,11 @@ class TestContextManagers:
         assert "operation_id" not in context_vars
         assert "component" not in context_vars
 
-        with operation_context("test-op"):
+        with logging_context(operation_id="test-op"):
             context_vars = structlog.contextvars.get_contextvars()
             assert context_vars.get("operation_id") == "test-op"
 
-            with component_context_manager("test-component"):
+            with logging_context(component="test-component"):
                 context_vars = structlog.contextvars.get_contextvars()
                 assert context_vars.get("component") == "test-component"
 
@@ -274,15 +145,16 @@ class TestContextManagers:
 
         def worker_function(worker_id: str) -> dict:
             """Worker function that sets and reads context in a thread."""
-            with operation_context(f"worker-{worker_id}"):
-                with component_context_manager(f"component-{worker_id}"):
-                    # Simulate some work
-                    import time
+            with logging_context(
+                operation_id=f"worker-{worker_id}", component=f"component-{worker_id}"
+            ):
+                # Simulate some work
+                import time
 
-                    time.sleep(0.01)
+                time.sleep(0.01)
 
-                    # Return the context as seen by this worker
-                    return dict(structlog.contextvars.get_contextvars())
+                # Return the context as seen by this worker
+                return dict(structlog.contextvars.get_contextvars())
 
         # Run multiple workers concurrently
         with ThreadPoolExecutor(max_workers=3) as executor:
@@ -300,7 +172,7 @@ class TestContextManagers:
         assert "operation_id" not in context_vars
         assert "component" not in context_vars
 
-    def test_resource_context_manager_cleanup(self):
+    def test_logging_context_cleanup(self):
         """Test that resource context manager properly cleans up all bound variables."""
         import structlog.contextvars
 
@@ -312,7 +184,7 @@ class TestContextManagers:
         assert len(context_vars) == 0
 
         # Test with all possible parameters
-        with resource_context_manager(
+        with logging_context(
             resource_type="Service",
             resource_namespace="test-namespace",
             resource_name="test-service",
@@ -331,7 +203,7 @@ class TestContextManagers:
         context_vars = structlog.contextvars.get_contextvars()
         assert len(context_vars) == 0
 
-    def test_resource_context_manager_partial_parameters(self):
+    def test_logging_context_partial_parameters(self):
         """Test resource context manager with only some parameters set."""
         import structlog.contextvars
 
@@ -339,7 +211,7 @@ class TestContextManagers:
         structlog.contextvars.clear_contextvars()
 
         # Test with only resource_type
-        with resource_context_manager(resource_type="Pod"):
+        with logging_context(resource_type="Pod"):
             context_vars = structlog.contextvars.get_contextvars()
             assert len(context_vars) == 1
             assert context_vars["resource_type"] == "Pod"
@@ -349,7 +221,7 @@ class TestContextManagers:
         assert len(context_vars) == 0
 
         # Test with no parameters (should be no-op)
-        with resource_context_manager():
+        with logging_context():
             context_vars = structlog.contextvars.get_contextvars()
             assert len(context_vars) == 0
 
@@ -405,7 +277,7 @@ class TestConvenienceFunctions:
         """Test structured logger factory function."""
         setup_structured_logging(verbose_level=1, use_json=False)
 
-        logger = get_structured_logger("test.module")
+        logger = structlog.get_logger("test.module")
 
         # Verify logger has required logging methods
         assert hasattr(logger, "debug")
@@ -430,39 +302,38 @@ class TestIntegration:
         # Clear existing handlers to avoid interference
         root_logger.handlers = [handler]
 
-        structured_logger = get_structured_logger("integration_test")
+        structured_logger = structlog.get_logger("integration_test")
 
         # Simulate operator workflow with nested contexts
-        with operation_context("workflow-123") as op_id:
-            with component_context_manager("operator"):
-                # Log configuration change
-                with resource_context_manager(
-                    resource_type="ConfigMap",
-                    resource_namespace="default",
-                    resource_name="haproxy-config",
-                ):
-                    structured_logger.info(
-                        "Configuration changed",
-                        change_type="template_update",
-                        maps_count=3,
-                    )
+        with logging_context(operation_id="workflow-123") as op_id:
+            with logging_context(
+                component="operator",
+                resource_type="ConfigMap",
+                resource_namespace="default",
+                resource_name="haproxy-config",
+            ):
+                structured_logger.info(
+                    "Configuration changed",
+                    change_type="template_update",
+                    maps_count=3,
+                )
 
-                # Log template rendering
-                with resource_context_manager(template_type="map"):
-                    structured_logger.info(
-                        "Template render",
-                        template_operation="render",
-                        duration=0.042,
-                        success=True,
-                    )
+            # Log template rendering
+            with logging_context(component="operator", template_type="map"):
+                structured_logger.info(
+                    "Template render",
+                    template_operation="render",
+                    duration=0.042,
+                    success=True,
+                )
 
-                # Log Dataplane API call
-                with resource_context_manager(pod_name="haproxy-production-1"):
-                    structured_logger.info(
-                        "Dataplane API deploy",
-                        dataplane_operation="deploy",
-                        version="1.2.3",
-                    )
+            # Log Dataplane API call
+            with logging_context(component="operator", pod_name="haproxy-production-1"):
+                structured_logger.info(
+                    "Dataplane API deploy",
+                    dataplane_operation="deploy",
+                    version="1.2.3",
+                )
 
         # Parse all log entries
         output = stream.getvalue().strip()
@@ -497,26 +368,12 @@ class TestEdgeCases:
     """Test cases for edge cases and error conditions."""
 
     def test_performance_with_many_context_fields(self):
-        """Test performance of logfmt renderer with many context fields."""
+        """Test logging performance with many context fields."""
         # Setup structured logging
         setup_structured_logging(verbose_level=1, use_json=False)
 
-        # Create event dict with many fields
-        event_dict = {
-            "timestamp": "2025-01-01 12:00:00,000",
-            "level": "INFO",
-            "logger": "test.module",
-            "event": "Performance test",
-        }
+        logger = structlog.get_logger("performance_test")
 
-        # Add many context fields
-        for i in range(50):
-            event_dict[f"field_{i}"] = f"value_{i}"
-            event_dict[f"quoted_field_{i}"] = f"value with spaces {i}"
-
-        # Should not raise exceptions and should format correctly
-        result = custom_logfmt_renderer(None, None, event_dict)
-
-        assert "Performance test" in result
-        assert "field_0=value_0" in result
-        assert 'quoted_field_0="value with spaces 0"' in result
+        # Test with many context fields - should not raise exceptions
+        with logging_context(**{f"field_{i}": f"value_{i}" for i in range(20)}):
+            logger.info("Performance test with many fields")


### PR DESCRIPTION
Radical code simplification of structured logging module following the project's No Backward Compatibility Policy.

## Changes
- Remove custom_logfmt_renderer and custom_timestamp_processor functions (50 lines eliminated)
- Consolidate 3 separate context managers (operation_context, component_context_manager, resource_context_manager) into a single universal logging_context function
- Remove backward compatibility aliases and update all code to use logging_context directly with named parameters
- Replace get_structured_logger passthrough with direct structlog usage
- Update CLAUDE.md with proper test timeout guidelines for development workflow

## Impact
- Reduces structured_logging.py from 176 to 95 lines (46% reduction) 
- Total reduction of 233 lines across the codebase
- Eliminates all custom renderer code by leveraging structlog's built-in processors
- Simplifies API surface with single context manager instead of three
- All 428 unit tests pass

## Technical Details
The changes leverage structlog's existing capabilities instead of reinventing functionality. The new logging_context function supports all previous use cases with a cleaner API using keyword arguments.