### PR TITLE
fix: improve management socket kopf index serialization and HAProxy server naming

### DIFF
--- a/charts/haproxy-template-ic/values.yaml
+++ b/charts/haproxy-template-ic/values.yaml
@@ -195,7 +195,7 @@ webhook:
           {% for endpoint_slice in resources.get('endpoints', {}).get_indexed(service_name) %}
             {% for endpoint in endpoint_slice.endpoints %}
               {% for address in endpoint.addresses %}
-          server {{ service_name }}_{{ loop.index }} {{ address }}:{{ port }}
+          server {{ endpoint.targetRef.name }} {{ address }}:{{ port }}
               {% endfor %}
             {% endfor %}
           {% endfor %}

--- a/deploy/base/configmap.yaml
+++ b/deploy/base/configmap.yaml
@@ -91,7 +91,7 @@ data:
           {% for endpoint_slice in resources.get('endpoints', {}).get_indexed(service_name) %}
             {% for endpoint in endpoint_slice.endpoints %}
               {% for address in endpoint.addresses %}
-          server {{ service_name }}_{{ loop.index }} {{ address }}:{{ port }}
+          server {{ endpoint.targetRef.name }} {{ address }}:{{ port }}
               {% endfor %}
             {% endfor %}
           {% endfor %}

--- a/haproxy_template_ic/management_socket.py
+++ b/haproxy_template_ic/management_socket.py
@@ -74,13 +74,28 @@ def _serialize_kopf_index(index_data: KopfIndexData) -> Dict[str, List[ResourceD
     Raises:
         TypeError: If index_data cannot be serialized
     """
-    if not (hasattr(index_data, "__iter__") and hasattr(index_data, "__getitem__")):
+    # Check if it's a dict-like object (not just iterable like strings)
+    if not (
+        hasattr(index_data, "__iter__")
+        and hasattr(index_data, "__getitem__")
+        and hasattr(index_data, "items")
+    ):
         return {}
 
     serialized_index = {}
-    for key in index_data:
-        resources = index_data[key]
-        serialized_index[str(key)] = _serialize_resource_collection(resources)
+    try:
+        for key in index_data:
+            resources = index_data[key]
+            # Convert tuple keys to structured strings with ':' separator
+            # e.g., ('namespace', 'name') becomes 'namespace:name'
+            if isinstance(key, tuple):
+                serialized_key = ":".join(str(k) for k in key)
+            else:
+                serialized_key = str(key)
+            serialized_index[serialized_key] = _serialize_resource_collection(resources)
+    except (TypeError, KeyError):
+        # Handle cases where index_data doesn't behave like a dict
+        return {}
 
     return serialized_index
 
@@ -294,15 +309,30 @@ class ManagementSocketServer:
 
     def _dump_indices(self) -> Dict[str, Any]:
         """Dump all indices from memo."""
-        return {
-            "indices": {
-                name: dict(getattr(self.memo, name))
-                for name in dir(self.memo)
-                if name.endswith("_index")
+        indices: Dict[str, Any] = {}
+
+        # Handle new memo.indices dictionary structure
+        if hasattr(self.memo, "indices") and self.memo.indices:
+            for name, index_data in self.memo.indices.items():
+                try:
+                    indices[name] = _serialize_kopf_index(index_data)
+                except Exception as e:
+                    indices[name] = {"error": f"Failed to serialize: {e}"}
+
+        # Also check for old-style _index attributes for backward compatibility
+        for name in dir(self.memo):
+            if (
+                name.endswith("_index")
                 and not name.startswith("_")
                 and hasattr(getattr(self.memo, name), "items")
-            }
-        }
+            ):
+                if name not in indices:  # Don't override new-style indices
+                    try:
+                        indices[name] = dict(getattr(self.memo, name))
+                    except Exception as e:
+                        indices[name] = {"error": f"Failed to serialize: {e}"}
+
+        return {"indices": indices}
 
     def _dump_config(self) -> Dict[str, Any]:
         """Dump HAProxy configuration context."""

--- a/tests/unit/test_management_socket.py
+++ b/tests/unit/test_management_socket.py
@@ -14,7 +14,61 @@ from haproxy_template_ic.management_socket import (
     ManagementSocketServer,
     serialize_state,
     run_management_socket_server,
+    _serialize_kopf_index,
 )
+
+
+class TestSerializeKopfIndex:
+    """Test the _serialize_kopf_index function."""
+
+    def test_serialize_kopf_index_with_tuple_keys(self):
+        """Test that tuple keys are properly formatted with ':' separator."""
+        index_data = {
+            ("namespace", "name"): [{"metadata": {"name": "resource1"}}],
+            ("default", "my-service"): [{"metadata": {"name": "resource2"}}],
+            ("echo-server",): [
+                {"metadata": {"name": "resource3"}}
+            ],  # Single-element tuple
+        }
+
+        result = _serialize_kopf_index(index_data)
+
+        # Check that tuple keys are converted to structured strings
+        assert "namespace:name" in result
+        assert "default:my-service" in result
+        assert "echo-server" in result  # Single element tuple becomes just the element
+
+        # Check that the resources are preserved
+        assert result["namespace:name"][0]["metadata"]["name"] == "resource1"
+        assert result["default:my-service"][0]["metadata"]["name"] == "resource2"
+        assert result["echo-server"][0]["metadata"]["name"] == "resource3"
+
+    def test_serialize_kopf_index_with_string_keys(self):
+        """Test that string keys are preserved as-is."""
+        index_data = {
+            "simple-key": [{"metadata": {"name": "resource1"}}],
+            "another-key": [{"metadata": {"name": "resource2"}}],
+        }
+
+        result = _serialize_kopf_index(index_data)
+
+        assert "simple-key" in result
+        assert "another-key" in result
+        assert result["simple-key"][0]["metadata"]["name"] == "resource1"
+        assert result["another-key"][0]["metadata"]["name"] == "resource2"
+
+    def test_serialize_kopf_index_empty(self):
+        """Test serializing an empty index."""
+        result = _serialize_kopf_index({})
+        assert result == {}
+
+    def test_serialize_kopf_index_invalid_data(self):
+        """Test serializing invalid data returns empty dict."""
+        result = _serialize_kopf_index(None)
+        assert result == {}
+
+        result = _serialize_kopf_index("not an index")
+        assert result == {}
 
 
 class TestSerializeState:
@@ -238,11 +292,16 @@ class TestManagementSocketServer:
     @pytest.mark.asyncio
     async def test_process_command_dump_indices(self, server):
         """Test 'dump indices' command."""
+        # Set up new-style indices
+        server.memo.indices = {}  # Empty dict instead of Mock
+
+        # Set up old-style indices for backward compatibility test
         server.memo.resource_index = {"res1": "data1"}
         server.memo.config_index = {"conf1": "data1"}
 
         with patch(
-            "builtins.dir", return_value=["resource_index", "config_index", "other"]
+            "builtins.dir",
+            return_value=["resource_index", "config_index", "other", "indices"],
         ):
             result = await server._process_command("dump indices")
 
@@ -363,22 +422,43 @@ class TestManagementSocketServer:
         assert "Unknown command" in result["error"]
 
     def test_dump_indices(self, server):
-        """Test _dump_indices method."""
+        """Test _dump_indices method with new memo.indices structure."""
+        # Test new-style memo.indices dictionary
+        server.memo.indices = {
+            "ingresses": {
+                ("default", "my-ingress"): [{"metadata": {"name": "my-ingress"}}],
+                ("kube-system", "system-ingress"): [
+                    {"metadata": {"name": "system-ingress"}}
+                ],
+            },
+            "endpoints": {
+                ("echo-server",): [{"metadata": {"name": "echo-endpoint"}}],
+            },
+        }
+
+        # Also test old-style _index attributes for backward compatibility
         server.memo.resource_index = {"res1": "data1"}
         server.memo.config_index = {"conf1": "data1"}
         server.memo.other_attr = "not an index"
 
         with patch(
             "builtins.dir",
-            return_value=["resource_index", "config_index", "other_attr"],
+            return_value=["resource_index", "config_index", "other_attr", "indices"],
         ):
             result = server._dump_indices()
 
         assert "indices" in result
-        assert len(result["indices"]) == 2
+        # Should have both new-style indices and old-style indices
+        assert "ingresses" in result["indices"]
+        assert "endpoints" in result["indices"]
         assert "resource_index" in result["indices"]
         assert "config_index" in result["indices"]
         assert "other_attr" not in result["indices"]
+
+        # Check that tuple keys are properly serialized with ':' separator
+        assert "default:my-ingress" in result["indices"]["ingresses"]
+        assert "kube-system:system-ingress" in result["indices"]["ingresses"]
+        assert "echo-server" in result["indices"]["endpoints"]
 
     def test_dump_config_with_context(self, server):
         """Test _dump_config method with context."""


### PR DESCRIPTION
This PR addresses two issues related to kopf index handling and HAProxy server naming:

**Management Socket Index Serialization:**
The management socket's `_serialize_kopf_index` function now properly handles tuple keys that kopf uses for compound indices. Previously, tuple keys like `('namespace', 'name')` were converted to strings without proper formatting. Now they are converted to structured strings with ':' separator (e.g., `'namespace:name'`) for better readability in the socket's dump output.

**HAProxy Server Naming:**
Updated the HAProxy configuration templates to use `endpoint.targetRef.name` instead of generic `service_name_{{ loop.index }}` for server names. This provides more descriptive and meaningful server names in the HAProxy configuration, making debugging and monitoring easier.

**Changes:**
- Enhanced `_serialize_kopf_index()` to convert tuple keys to structured strings with ':' separator
- Added error handling for serialization failures in both new and old-style indices
- Updated HAProxy templates in charts and deploy manifests to use endpoint target names
- Added comprehensive unit tests for tuple key serialization scenarios