### PR TITLE
refactor: move local imports to module level

### DIFF
--- a/haproxy_template_ic/config_models.py
+++ b/haproxy_template_ic/config_models.py
@@ -26,6 +26,7 @@ custom validators, providing better maintainability and standardized error messa
 """
 
 from typing import Annotated, Any, Dict, Iterator, List, Optional, Tuple, TYPE_CHECKING
+import logging
 import os
 import unicodedata
 from collections import defaultdict
@@ -35,6 +36,8 @@ from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
 from pydantic.types import StringConstraints
 
 from haproxy_template_ic.constants import DEFAULT_DATAPLANE_PORT, DEFAULT_HEALTH_PORT
+from haproxy_template_ic.field_filter import validate_ignore_fields
+from haproxy_template_ic.kopf_utils import normalize_kopf_resource
 
 if TYPE_CHECKING:
     pass
@@ -254,12 +257,8 @@ class Config(BaseModel):
     @classmethod
     def validate_ignore_fields(cls, v: List[str]) -> List[str]:
         """Validate JSONPath expressions for field filtering."""
-        from haproxy_template_ic.field_filter import validate_ignore_fields
-
         validated = validate_ignore_fields(v)
         if len(validated) < len(v):
-            import logging
-
             logger = logging.getLogger(__name__)
             logger.warning(
                 f"Some ignore field expressions were invalid and removed. "
@@ -379,10 +378,6 @@ class IndexedResourceCollection(BaseModel):
         Returns:
             IndexedResourceCollection with filtered resources
         """
-        import logging
-
-        from haproxy_template_ic.kopf_utils import normalize_kopf_resource
-
         logger = logging.getLogger(__name__)
 
         collection = cls()
@@ -436,8 +431,6 @@ class IndexedResourceCollection(BaseModel):
         """Get single resource or raise if multiple found."""
         results = self.get_indexed(*args)
         if len(results) > 1:
-            import logging
-
             resource_ids = [self._extract_resource_id(r) for r in results[:3]]
             error_msg = (
                 f"Multiple resources found for key {args}: {len(results)} matches"

--- a/haproxy_template_ic/dataplane.py
+++ b/haproxy_template_ic/dataplane.py
@@ -11,6 +11,7 @@ Uses the complete generated HAProxy Dataplane API v3 client for all operations.
 """
 
 import asyncio
+import base64
 import io
 import logging
 import re
@@ -18,6 +19,8 @@ import time
 from datetime import datetime, UTC
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple
 from urllib.parse import urlparse, urlunparse
+
+import httpx
 
 if TYPE_CHECKING:
     from haproxy_template_ic.config_models import IndexedResourceCollection
@@ -470,9 +473,6 @@ class DataplaneClient:
     def _get_client(self) -> Any:
         """Lazy initialization of AuthenticatedClient object."""
         if self._client is None:
-            import base64
-            import httpx
-
             logger.debug(f"Creating dataplane client for {self.base_url}")
             # Create basic auth token from username and password
             auth_string = f"{self.auth[0]}:{self.auth[1]}"
@@ -534,8 +534,6 @@ class DataplaneClient:
             ValidationError: If configuration validation fails
             DataplaneAPIError: If API communication fails
         """
-        import httpx
-
         with trace_dataplane_operation("validate", self.base_url):
             add_span_attributes(
                 config_size=len(config_content), dataplane_url=self.base_url
@@ -619,8 +617,6 @@ class DataplaneClient:
         temporary dataplane unavailability), but excludes validation errors
         from retries since retrying won't fix config errors.
         """
-        import httpx
-
         with trace_dataplane_operation("deploy", self.base_url):
             add_span_attributes(
                 config_size=len(config_content), dataplane_url=self.base_url

--- a/haproxy_template_ic/kopf_utils.py
+++ b/haproxy_template_ic/kopf_utils.py
@@ -9,6 +9,8 @@ These utilities should only be used within IndexedResourceCollection.from_kopf_i
 import logging
 from typing import Any, Dict, List, Optional
 
+from haproxy_template_ic.field_filter import remove_fields_from_resource
+
 logger = logging.getLogger(__name__)
 
 
@@ -74,8 +76,6 @@ def normalize_kopf_resource(
 
     # Apply field filtering if specified
     if ignore_fields:
-        from haproxy_template_ic.field_filter import remove_fields_from_resource
-
         result = remove_fields_from_resource(result, ignore_fields)
 
     return result

--- a/haproxy_template_ic/operator.py
+++ b/haproxy_template_ic/operator.py
@@ -6,14 +6,16 @@ resource watchers, configuration management, and the main operator loop.
 """
 
 import asyncio
+import atexit
 import logging
+import os
+import shutil
+import tempfile
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Dict, Tuple
 
 if TYPE_CHECKING:
     from haproxy_template_ic.__main__ import CliOptions
-
-import os
 
 import jsonpath
 from jsonpath.exceptions import JSONPathError
@@ -31,6 +33,7 @@ from kubernetes import config
 from haproxy_template_ic.config_models import (
     Config,
     HAProxyConfigContext,
+    IndexedResourceCollection,
     PodSelector,
     RenderedContent,
     RenderedConfig,
@@ -49,6 +52,7 @@ from haproxy_template_ic.management_socket import run_management_socket_server
 from haproxy_template_ic.metrics import get_metrics_collector
 from haproxy_template_ic.structured_logging import autolog, observe
 from haproxy_template_ic.templating import TemplateRenderer
+from haproxy_template_ic.webhook import register_validation_webhooks_from_config
 from haproxy_template_ic.credentials import Credentials
 from haproxy_template_ic.constants import (
     CONTENT_TYPE_CERTIFICATE,
@@ -123,8 +127,6 @@ def _get_haproxy_pod_collection(memo: Any) -> Any:
 
     haproxy_pods_store = memo.indices[HAPROXY_PODS_INDEX]
     logger.info(f"🔍 HAProxy pods index contains {len(haproxy_pods_store)} entries")
-
-    from haproxy_template_ic.config_models import IndexedResourceCollection
 
     haproxy_pods_collection = IndexedResourceCollection.from_kopf_index(
         haproxy_pods_store
@@ -305,8 +307,6 @@ async def load_config_from_configmap(configmap) -> Any:
     config = config_from_dict(yaml.safe_load(config_data))
 
     # Register validation webhooks based on configuration
-    from haproxy_template_ic.webhook import register_validation_webhooks_from_config
-
     register_validation_webhooks_from_config(config)
 
     return config
@@ -529,8 +529,6 @@ async def update_resource_index(
 
 def _collect_resource_indices(memo: Any, metrics: Any) -> Dict[str, Any]:
     """Collect all resource indices as IndexedResourceCollections."""
-    from haproxy_template_ic.config_models import IndexedResourceCollection
-
     indices: Dict[str, IndexedResourceCollection] = {}
 
     # Get the ignore_fields configuration
@@ -990,11 +988,6 @@ def configure_webhook_server(
     settings: kopf.OperatorSettings, memo: Any, **kwargs: Any
 ) -> None:
     """Configure webhook server for admission control."""
-    import atexit
-    import os
-    import shutil
-    import tempfile
-
     # Check if any resources have webhook validation enabled
     has_webhooks = any(
         getattr(watch_config, "enable_validation_webhook", False)

--- a/haproxy_template_ic/templating.py
+++ b/haproxy_template_ic/templating.py
@@ -7,6 +7,7 @@ functionality including support for template snippets and custom filters.
 
 import base64
 import os
+import re
 from functools import lru_cache
 from typing import Any, Callable, Dict, Optional
 
@@ -23,6 +24,7 @@ from jinja2 import (
 
 # Import Pydantic models and collection type aliases
 from .config_models import (
+    TemplateSnippet,
     TemplateSnippetCollection,
 )
 from .constants import (
@@ -77,8 +79,6 @@ def get_path_filter(
         raise ValueError(f"Invalid filename contains prohibited characters: {filename}")
 
     # Additional security checks for our specific use case (stricter than pathvalidate)
-    import re
-
     # Block directory names and path components
     if filename in (".", ".."):
         raise ValueError(f"Invalid filename contains prohibited characters: {filename}")
@@ -370,8 +370,6 @@ class TemplateRenderer:
 
 def _extract_snippet_templates(config_dict: dict) -> TemplateSnippetCollection:
     """Extract snippet templates from config dictionary."""
-    from .config_models import TemplateSnippet
-
     snippets = {}
     snippets_raw = config_dict.get("template_snippets", {})
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,9 @@
 # =============================================================================
 
 # Standard library imports
+import hashlib
 import logging
+import os
 import subprocess
 import time
 from datetime import datetime, timedelta
@@ -11,6 +13,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 # Third-party imports
+import httpx
 import kr8s
 import pytest
 import yaml
@@ -19,14 +22,17 @@ from python_on_whales import DockerClient
 
 # Kubernetes objects
 from kr8s.objects import (
+    APIObject,
     ClusterRoleBinding,
     ConfigMap,
+    Deployment,
     Namespace,
     Pod,
     Secret,
     Service,
     ServiceAccount,
 )
+from kr8s._exceptions import ServerError
 
 # Pytest plugins
 from pytest_kind.cluster import KindCluster
@@ -34,6 +40,15 @@ from pytest_shared_session_scope import (
     CleanupToken,
     SetupToken,
     shared_session_scope_pickle,
+)
+
+# Local imports
+from .coverage_extraction import extract_coverage_from_pod
+from tests.e2e.utils.k8s_helpers import print_pod_logs_on_failure
+from tests.webhook_certs import (
+    create_cert_secret_manifest,
+    create_validating_webhook_config,
+    generate_webhook_certificates,
 )
 
 
@@ -175,10 +190,6 @@ def setup_webhook_volumes_and_mounts(k8s_client, k8s_namespace, needs_webhook):
 
     try:
         # Try to create webhook secret
-        from tests.webhook_certs import (
-            create_cert_secret_manifest,
-            generate_webhook_certificates,
-        )
 
         webhook_certificates = generate_webhook_certificates(
             "haproxy-template-ic-webhook", k8s_namespace
@@ -432,7 +443,6 @@ def k8s_namespace(request, k8s_client):
 
     Resource tracking ensures proper cleanup and provides debugging information.
     """
-    import hashlib
 
     # Use module-level logger
 
@@ -658,7 +668,6 @@ def configmap(config_dict, k8s_client, k8s_namespace):
 @pytest.fixture
 def webhook_certificates(k8s_namespace):
     """Generate webhook certificates for the test namespace."""
-    from tests.webhook_certs import generate_webhook_certificates
 
     return generate_webhook_certificates("haproxy-template-ic-webhook", k8s_namespace)
 
@@ -666,7 +675,6 @@ def webhook_certificates(k8s_namespace):
 @pytest.fixture
 def webhook_secret(webhook_certificates, k8s_client, k8s_namespace):
     """Create Kubernetes Secret with webhook certificates."""
-    from tests.webhook_certs import create_cert_secret_manifest
 
     manifest = create_cert_secret_manifest(
         webhook_certificates, "haproxy-template-ic-webhook-certs", k8s_namespace
@@ -702,9 +710,6 @@ def credentials_secret(k8s_client, k8s_namespace):
 @pytest.fixture
 def validating_webhook_config(webhook_certificates, k8s_namespace, k8s_client):
     """Create ValidatingAdmissionWebhook configuration."""
-    from kr8s.objects import APIObject
-
-    from tests.webhook_certs import create_validating_webhook_config
 
     manifest = create_validating_webhook_config(
         webhook_name=f"haproxy-template-ic-webhook-{k8s_namespace}",
@@ -767,7 +772,6 @@ def unified_haproxy_configmap(k8s_client, k8s_namespace):
 
     This provides the same unified approach used in production deployments.
     """
-    from kr8s.objects import ConfigMap
 
     configmap = ConfigMap(
         {
@@ -889,8 +893,6 @@ def haproxy_deployment(k8s_client, k8s_namespace, unified_haproxy_configmap, req
     Use with parametrize: @pytest.mark.parametrize('haproxy_deployment', [3], indirect=True)
     """
     replicas = getattr(request, "param", 2) if hasattr(request, "param") else 2
-
-    from kr8s.objects import Deployment
 
     deployment = Deployment(
         {
@@ -1030,7 +1032,6 @@ def haproxy_deployment(k8s_client, k8s_namespace, unified_haproxy_configmap, req
     deployment.create()
 
     # Wait for deployment to be ready
-    import time
 
     max_wait = 60
     start_time = time.time()
@@ -1231,14 +1232,12 @@ def haproxy_dataplane_clients(haproxy_production_pods, k8s_namespace):
     Provides HTTP clients configured to communicate with the Dataplane API
     containers in the production HAProxy pods.
     """
-    import httpx
 
     clients = []
     for pod in haproxy_production_pods:
         pod_ip = pod.status.podIP
         if not pod_ip:
             # Wait for pod IP assignment
-            import time
 
             for _ in range(30):
                 pod.refresh()
@@ -1308,7 +1307,6 @@ def controller_with_validation_sidecar(
         ).create()
     except Exception as e:
         # Handle specific k8s errors for idempotent resource creation
-        from kr8s._exceptions import ServerError
 
         if isinstance(e, ServerError) and "already exists" in str(e):
             # Resource already exists, which is expected in test environments
@@ -1547,7 +1545,6 @@ backend validation_backend
 
     except Exception as e:
         # Handle specific k8s errors for idempotent pod creation
-        from kr8s._exceptions import ServerError
 
         if isinstance(e, ServerError) and "already exists" in str(e):
             # Pod already exists, get the existing one
@@ -1645,7 +1642,6 @@ def simple_controller(
         ).create()
     except Exception as e:
         # Handle specific k8s errors for idempotent resource creation
-        from kr8s._exceptions import ServerError
 
         if isinstance(e, ServerError) and "already exists" in str(e):
             # Resource already exists, which is expected in test environments
@@ -1748,7 +1744,6 @@ def simple_controller(
         pod.create()
     except Exception as e:
         # Handle specific k8s errors for idempotent pod creation
-        from kr8s._exceptions import ServerError
 
         if isinstance(e, ServerError) and "already exists" in str(e):
             # Pod already exists, get the existing one
@@ -1794,8 +1789,6 @@ def validation_dataplane_client(controller_with_validation_sidecar):
     Provides HTTP client configured to communicate with the validation
     Dataplane API container in the controller pod.
     """
-    import httpx
-    import time
 
     # Get pod IP
     controller_pod = controller_with_validation_sidecar
@@ -1913,8 +1906,6 @@ def collect_coverage(request, controller_with_validation_sidecar):
     if not request.config.getoption("--coverage"):
         return
 
-    from .coverage_extraction import extract_coverage_from_pod
-
     coverage_file = extract_coverage_from_pod(
         controller_with_validation_sidecar, request.node.name, request.config.rootpath
     )
@@ -1934,7 +1925,6 @@ def pytest_runtest_teardown(item, nextitem):
         PYTEST_DISABLE_POD_LOG_PRINTING: Set to 'true' to disable automatic log printing
         PYTEST_POD_FIXTURE_NAMES: Comma-separated list of fixture names to search for pods
     """
-    import os
 
     # Use module-level logger
 
@@ -1985,8 +1975,6 @@ def pytest_runtest_teardown(item, nextitem):
 
             if pod is not None:
                 try:
-                    from tests.e2e.utils.k8s_helpers import print_pod_logs_on_failure
-
                     logger.info(
                         f"Printing pod logs for failed test {item.name} using fixture {found_fixture}"
                     )

--- a/tests/e2e/test_config_management.py
+++ b/tests/e2e/test_config_management.py
@@ -7,6 +7,7 @@ and apply new settings correctly.
 """
 
 import pytest
+import time
 import yaml
 
 from tests.e2e.utils import (
@@ -90,7 +91,6 @@ def test_no_reload_loop_on_repeated_events(
         )
 
         # Small delay to ensure the event is processed
-        import time
 
         time.sleep(2)
 

--- a/tests/e2e/test_pod_discovery.py
+++ b/tests/e2e/test_pod_discovery.py
@@ -7,6 +7,7 @@ of deployment scaling operations.
 """
 
 import asyncio
+import ast
 import re
 import time
 
@@ -67,8 +68,6 @@ def get_pod_ips_from_socket_response(response):
                     # Handle string representation of dictionaries
                     if isinstance(resource, str):
                         try:
-                            import ast
-
                             resource = ast.literal_eval(resource)
                         except (ValueError, SyntaxError):
                             continue

--- a/tests/e2e/utils/operator_helpers.py
+++ b/tests/e2e/utils/operator_helpers.py
@@ -173,7 +173,6 @@ def count_log_occurrences(pod, pattern, timeout=30):
     Returns:
         int: Number of times the pattern was found in logs
     """
-    import time
 
     collected_logs = []
     start_time = time.time()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,6 +6,10 @@ to test interactions with HAProxy and Dataplane API.
 """
 
 import asyncio
+import logging
+import os
+import threading
+from pathlib import Path
 from typing import Dict, Tuple
 
 import httpx
@@ -28,7 +32,6 @@ from pytest_shared_session_scope import (
     shared_session_scope_pickle,
 )
 from python_on_whales import DockerClient
-from pathlib import Path
 
 
 # Store test results for --keep-containers on-failure
@@ -211,7 +214,6 @@ def event_loop():
 @pytest.fixture(scope="session")
 def docker_resource_semaphore():
     """Limit concurrent Docker operations to prevent resource exhaustion."""
-    import threading
 
     # Allow max 6 concurrent Docker operations to reduce port contention
     semaphore = threading.Semaphore(6)
@@ -310,8 +312,6 @@ def pytest_configure(config):
     pytest.current_config = config
 
     # Configure logging for pytest-xdist compatibility
-    import os
-    import logging
 
     worker_id = os.environ.get("PYTEST_XDIST_WORKER")
     if worker_id is not None:

--- a/tests/integration/utils/__init__.py
+++ b/tests/integration/utils/__init__.py
@@ -16,8 +16,13 @@ import filelock
 import httpx
 from python_on_whales import DockerClient
 
-from .progress import TestProgressReporter, ContainerWaitReporter, get_test_reporter
-from .progress import progress_context as progress_context
+from .progress import (
+    TestProgressReporter,
+    ContainerWaitReporter,
+    get_test_reporter,
+    progress_context as progress_context,
+    format_troubleshooting_info,
+)
 
 
 def find_free_port(used_ports: set, max_retries: int = 10) -> int:
@@ -509,7 +514,6 @@ class DockerComposeManager:
                     self.container_logs[container] = f"Failed to get logs: {e}"
 
             # Format troubleshooting information
-            from .progress import format_troubleshooting_info
 
             troubleshooting_info = format_troubleshooting_info(
                 self.compose_file, self.ports, failed_services, self.container_logs

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,19 +1,26 @@
+import base64
 import pytest
+import unicodedata
 from pydantic import ValidationError
+from unittest.mock import MagicMock, PropertyMock, patch
 
+from jinja2 import Template, TemplateNotFound
 from haproxy_template_ic.templating import TemplateRenderer
 from haproxy_template_ic.config_models import (
     Config,
-    WatchResourceConfig,
-    TemplateConfig,
+    ContentType,
+    HAProxyConfigContext,
+    IndexedResourceCollection,
     PodSelector,
-    config_from_dict,
     RenderedContent,
     RenderedConfig,
+    ResourceFilter,
+    TemplateConfig,
     TemplateContext,
-    HAProxyConfigContext,
+    TemplateSnippet,
+    WatchResourceConfig,
+    config_from_dict,
 )
-from jinja2 import Template
 
 
 # DELETED: ensure_auth_fields helper - credentials now come from Kubernetes Secrets
@@ -368,7 +375,6 @@ def test_rendered_map_is_frozen():
 # TemplateContext Tests
 def test_template_context_creation():
     """Test TemplateContext dataclass creation."""
-    from haproxy_template_ic.config_models import IndexedResourceCollection
 
     # Create an IndexedResourceCollection for test_resource
     test_collection = IndexedResourceCollection()
@@ -393,7 +399,6 @@ def test_template_context_default_resources():
 
 def test_template_context_is_frozen():
     """Test that TemplateContext is immutable."""
-    from haproxy_template_ic.config_models import IndexedResourceCollection
 
     # Create an IndexedResourceCollection for pods
     pods_collection = IndexedResourceCollection()
@@ -416,7 +421,6 @@ def test_template_context_is_frozen():
 def test_haproxy_config_context_creation():
     """Test HAProxyConfigContext dataclass creation."""
     # Create required config and template_context
-    from haproxy_template_ic.config_models import Config, PodSelector, TemplateContext
 
     config = Config(
         pod_selector=PodSelector(match_labels={"app": "test"}),
@@ -438,7 +442,6 @@ def test_haproxy_config_context_with_custom_data():
     rendered_maps = [rendered_map]
 
     # Create required config and template_context
-    from haproxy_template_ic.config_models import Config, PodSelector, TemplateContext
 
     config = Config(
         pod_selector=PodSelector(match_labels={"app": "test"}),
@@ -456,7 +459,6 @@ def test_haproxy_config_context_with_custom_data():
 
 def test_haproxy_config_context_mutable():
     """Test that HAProxyConfigContext is mutable (not frozen)."""
-    from haproxy_template_ic.config_models import Config, PodSelector, TemplateContext
 
     config = Config(
         pod_selector=PodSelector(match_labels={"app": "test"}),
@@ -594,7 +596,6 @@ def test_haproxy_config_context_default_rendered_certificates():
 
 def test_watch_resource_collection_by_id():
     """Test watch resource collection access by key."""
-    from haproxy_template_ic.config_models import WatchResourceConfig
 
     resources = {
         "pods": WatchResourceConfig(kind="Pod", api_version="v1"),
@@ -620,7 +621,6 @@ def test_watch_resource_collection_by_id():
 
 def test_map_collection_by_path():
     """Test map collection access by path key."""
-    from haproxy_template_ic.config_models import TemplateConfig
 
     maps = {
         "backend.map": TemplateConfig(template="backend map"),
@@ -644,7 +644,6 @@ def test_map_collection_by_path():
 
 def test_template_snippet_collection_by_name():
     """Test template snippet collection access by name (dict-based)."""
-    from haproxy_template_ic.config_models import TemplateSnippet
 
     snippets = {
         "backend-servers": TemplateSnippet(
@@ -693,14 +692,6 @@ def test_certificate_collection_by_name():
 
 def test_template_context_get_methods():
     """Test TemplateContext helper methods."""
-    from haproxy_template_ic.config_models import (
-        TemplateContext,
-        Config,
-        TemplateConfig,
-        TemplateSnippet,
-        PodSelector,
-        WatchResourceConfig,
-    )
 
     # Create config with collections for testing
     test_config = Config(
@@ -730,7 +721,6 @@ def test_template_context_get_methods():
     assert test_config.certificates.get("nonexistent.pem") is None
 
     # Test basic template context functionality
-    from haproxy_template_ic.config_models import IndexedResourceCollection
 
     test_collection = IndexedResourceCollection()
     context_basic = TemplateContext(resources={"test": test_collection})
@@ -762,7 +752,6 @@ def test_config_from_dict_error_conditions():
 
 def test_parse_pod_selector_errors():
     """Test pod_selector validation error conditions."""
-    from haproxy_template_ic.config_models import config_from_dict
 
     # Test invalid pod_selector type - Pydantic validation
     with pytest.raises(ValueError):
@@ -1220,7 +1209,6 @@ def test_template_snippet_not_found_error():
     map_config = config.maps.get("error.map")
 
     # Should raise TemplateNotFound when trying to render
-    from jinja2 import TemplateNotFound
 
     with pytest.raises(TemplateNotFound, match="non-existent-snippet"):
         TemplateRenderer.from_config(config).get_compiled(map_config.template).render()
@@ -1363,7 +1351,6 @@ def test_template_snippet_update_during_config_reload():
 
 def test_template_context_helper_methods():
     """Test the new helper methods for resource access."""
-    from haproxy_template_ic.config_models import IndexedResourceCollection
 
     # Create IndexedResourceCollections for each resource type
     ingresses_collection = IndexedResourceCollection()
@@ -1455,7 +1442,6 @@ def test_template_compilation():
 
 def test_b64decode_filter():
     """Test the custom base64 decode filter."""
-    import base64
 
     # Test valid base64 string using the new config system
     test_string = "Hello, World!"
@@ -1632,7 +1618,6 @@ def test_host_map_template_rendering():
     config = config_from_dict(config_dict.copy())
 
     # Create mock ingress resources using IndexedResourceCollection
-    from haproxy_template_ic.config_models import IndexedResourceCollection
 
     ingresses_collection = IndexedResourceCollection()
     ingresses_collection._internal_dict[("default", "test-ingress")] = [
@@ -1684,7 +1669,6 @@ def test_host_map_template_rendering():
 
 def test_complete_ingress_configuration_with_certificates():
     """Test a complete ingress controller configuration including certificates with b64decode."""
-    import base64
 
     # Create TLS certificate data
     cert_data = (
@@ -1717,7 +1701,6 @@ def test_complete_ingress_configuration_with_certificates():
     config = config_from_dict(config_dict.copy())
 
     # Create mock TLS secret using IndexedResourceCollection
-    from haproxy_template_ic.config_models import IndexedResourceCollection
 
     secrets_collection = IndexedResourceCollection()
     secrets_collection._internal_dict[("default", "example-tls")] = [
@@ -1858,7 +1841,6 @@ def test_watch_resource_config_version_property():
 
 def test_template_snippet_name_validation():
     """Test TemplateSnippet name validation in config."""
-    from haproxy_template_ic.config_models import TemplateSnippet
 
     # Test valid snippet creation
     snippet = TemplateSnippet(name="valid-name", template="test template")
@@ -1882,7 +1864,6 @@ def test_template_snippet_name_validation():
 
 def test_resource_filter_creation():
     """Test ResourceFilter model creation."""
-    from haproxy_template_ic.config_models import ResourceFilter
 
     # Test with all fields
     filter_obj = ResourceFilter(
@@ -1901,7 +1882,6 @@ def test_resource_filter_creation():
 
 def test_pod_selector_frozen():
     """Test that PodSelector is frozen."""
-    from haproxy_template_ic.config_models import PodSelector
 
     selector = PodSelector(match_labels={"app": "test"})
 
@@ -1915,7 +1895,6 @@ class TestFilenameSecurity:
 
     def test_filename_validation_valid_cases(self):
         """Test that valid filenames are accepted."""
-        from haproxy_template_ic.config_models import RenderedContent, ContentType
 
         valid_filenames = [
             "host.map",
@@ -1941,7 +1920,6 @@ class TestFilenameSecurity:
 
     def test_filename_validation_invalid_characters_blocked(self):
         """Test that filenames with invalid characters are blocked (now includes spaces and Unicode)."""
-        from haproxy_template_ic.config_models import RenderedContent, ContentType
 
         invalid_filenames = [
             "host file.map",  # Spaces no longer allowed for security
@@ -1966,7 +1944,6 @@ class TestFilenameSecurity:
 
     def test_filename_validation_path_traversal_blocked(self):
         """Test that path traversal attempts in filenames are blocked."""
-        from haproxy_template_ic.config_models import RenderedContent, ContentType
 
         path_traversal_attempts = [
             "../../../etc/passwd",
@@ -1995,7 +1972,6 @@ class TestFilenameSecurity:
 
     def test_filename_validation_directory_names_blocked(self):
         """Test that directory names like '.' and '..' are blocked by pattern validation."""
-        from haproxy_template_ic.config_models import RenderedContent, ContentType
 
         directory_names = [".", ".."]
 
@@ -2009,7 +1985,6 @@ class TestFilenameSecurity:
 
     def test_filename_validation_null_byte_blocked(self):
         """Test that null byte injection in filenames is blocked."""
-        from haproxy_template_ic.config_models import RenderedContent, ContentType
 
         null_byte_attempts = [
             "host.map\x00",
@@ -2028,7 +2003,6 @@ class TestFilenameSecurity:
 
     def test_filename_validation_length_limits(self):
         """Test filename length validation."""
-        from haproxy_template_ic.config_models import RenderedContent, ContentType
 
         # Test maximum length (255 characters)
         max_valid_filename = "a" * 255
@@ -2128,7 +2102,6 @@ class TestFilenameSecurity:
 
     def test_filename_validation_comprehensive_attacks(self):
         """Test comprehensive filename attack scenarios."""
-        from haproxy_template_ic.config_models import RenderedContent, ContentType
 
         # These attacks should be blocked by the regex pattern
         path_attacks = [
@@ -2171,7 +2144,6 @@ class TestFilenameSecurity:
 
     def test_content_type_enum_security(self):
         """Test that ContentType enum prevents invalid content types."""
-        from haproxy_template_ic.config_models import RenderedContent, ContentType
 
         # Valid content types
         valid_types = [ContentType.MAP, ContentType.CERTIFICATE, ContentType.FILE]
@@ -2219,7 +2191,6 @@ class TestFieldValidators:
 
     def test_validate_ignore_fields_with_invalid_expressions(self):
         """Test that invalid JSONPath expressions trigger warning."""
-        from unittest.mock import patch, MagicMock
 
         with patch(
             "haproxy_template_ic.field_filter.validate_ignore_fields"
@@ -2258,8 +2229,6 @@ class TestIndexedResourceCollectionFromKopfIndex:
 
     def test_from_kopf_index_size_limit_reached(self):
         """Test warning when size limit is reached."""
-        from unittest.mock import MagicMock, patch
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         # Create a mock index with more items than max_size
         mock_index = MagicMock()
@@ -2293,8 +2262,6 @@ class TestIndexedResourceCollectionFromKopfIndex:
 
     def test_from_kopf_index_normalization_failure(self):
         """Test handling of resource normalization failures."""
-        from unittest.mock import MagicMock, patch
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         mock_index = MagicMock()
         mock_index.__iter__.return_value = iter([("key1",)])
@@ -2321,8 +2288,6 @@ class TestIndexedResourceCollectionFromKopfIndex:
 
     def test_from_kopf_index_invalid_resource(self):
         """Test warning for invalid resources."""
-        from unittest.mock import MagicMock, patch
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         mock_index = MagicMock()
         mock_index.__iter__.return_value = iter([("key1",)])
@@ -2349,8 +2314,6 @@ class TestIndexedResourceCollectionFromKopfIndex:
 
     def test_from_kopf_index_general_exception(self):
         """Test handling of general exceptions during indexing."""
-        from unittest.mock import MagicMock, patch
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         mock_index = MagicMock()
         mock_index.__iter__.return_value = iter([("key1",)])
@@ -2377,8 +2340,6 @@ class TestIndexedResourceCollectionHelperMethods:
 
     def test_normalize_key_with_tuple_input(self):
         """Test _normalize_key with tuple input."""
-        from haproxy_template_ic.config_models import IndexedResourceCollection
-        import unicodedata
 
         collection = IndexedResourceCollection()
 
@@ -2409,8 +2370,6 @@ class TestIndexedResourceCollectionHelperMethods:
 
     def test_validate_resource_with_object(self):
         """Test _validate_resource with object having metadata attribute."""
-        from unittest.mock import MagicMock
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         collection = IndexedResourceCollection()
 
@@ -2430,7 +2389,6 @@ class TestIndexedResourceCollectionHelperMethods:
 
     def test_validate_resource_edge_cases(self):
         """Test _validate_resource with edge cases."""
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         collection = IndexedResourceCollection()
 
@@ -2448,8 +2406,6 @@ class TestIndexedResourceCollectionHelperMethods:
 
     def test_extract_resource_id_with_object(self):
         """Test _extract_resource_id with object having metadata."""
-        from unittest.mock import MagicMock
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         collection = IndexedResourceCollection()
 
@@ -2469,7 +2425,6 @@ class TestIndexedResourceCollectionHelperMethods:
 
     def test_extract_resource_id_with_dict(self):
         """Test _extract_resource_id with dictionary."""
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         collection = IndexedResourceCollection()
 
@@ -2488,8 +2443,6 @@ class TestIndexedResourceCollectionHelperMethods:
 
     def test_extract_resource_id_exception(self):
         """Test _extract_resource_id exception handling."""
-        from unittest.mock import MagicMock, PropertyMock
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         collection = IndexedResourceCollection()
 
@@ -2515,7 +2468,6 @@ class TestIndexedResourceCollectionQueryMethods:
 
     def test_get_indexed_iter(self):
         """Test get_indexed_iter method."""
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         collection = IndexedResourceCollection()
 
@@ -2537,8 +2489,6 @@ class TestIndexedResourceCollectionQueryMethods:
 
     def test_get_indexed_single_multiple_resources(self):
         """Test get_indexed_single with multiple resources."""
-        from unittest.mock import patch, MagicMock
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         collection = IndexedResourceCollection()
 
@@ -2562,7 +2512,6 @@ class TestIndexedResourceCollectionQueryMethods:
 
     def test_items_iteration(self):
         """Test items method."""
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         collection = IndexedResourceCollection()
 
@@ -2579,7 +2528,6 @@ class TestIndexedResourceCollectionQueryMethods:
 
     def test_values_iteration(self):
         """Test values method."""
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         collection = IndexedResourceCollection()
 
@@ -2595,7 +2543,6 @@ class TestIndexedResourceCollectionQueryMethods:
 
     def test_contains_check(self):
         """Test __contains__ method."""
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         collection = IndexedResourceCollection()
 
@@ -2608,7 +2555,6 @@ class TestIndexedResourceCollectionQueryMethods:
 
     def test_keys_iteration(self):
         """Test keys method."""
-        from haproxy_template_ic.config_models import IndexedResourceCollection
 
         collection = IndexedResourceCollection()
 
@@ -2627,12 +2573,6 @@ class TestHAProxyConfigContextMethods:
 
     def test_get_content_by_filename_not_found(self):
         """Test get_content_by_filename when content not found."""
-        from haproxy_template_ic.config_models import (
-            Config,
-            HAProxyConfigContext,
-            TemplateContext,
-            RenderedContent,
-        )
 
         config = Config(
             pod_selector={"match_labels": {"app": "test"}},

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1,5 +1,6 @@
 """Tests for credential management with Pydantic models."""
 
+import base64
 import pytest
 import click
 from pydantic import ValidationError
@@ -187,7 +188,6 @@ def test_decode_field_bytes_invalid_base64():
 def test_decode_field_bytes_invalid_unicode():
     """Test _decode_field with bytes that decode to invalid unicode."""
     # This creates bytes that are valid base64 but decode to invalid unicode
-    import base64
 
     invalid_unicode_bytes = base64.b64encode(b"\xff\xfe\xfd")
     result = _decode_field(invalid_unicode_bytes)
@@ -213,7 +213,6 @@ def test_decode_field_string_fallback():
 def test_decode_field_string_unicode_error_fallback():
     """Test _decode_field string unicode error fallback."""
     # Create a base64 string that decodes to invalid unicode
-    import base64
 
     invalid_unicode_b64 = base64.b64encode(b"\xff\xfe\xfd").decode("ascii")
     result = _decode_field(invalid_unicode_b64)

--- a/tests/unit/test_dataplane.py
+++ b/tests/unit/test_dataplane.py
@@ -5,17 +5,26 @@ Tests the HAProxy Dataplane API integration including pod discovery,
 client operations, and configuration synchronization.
 """
 
+import asyncio
 import pytest
 from unittest.mock import Mock, AsyncMock, MagicMock, patch
 from unittest import mock
 
+import httpx
+from pydantic import SecretStr
+from haproxy_dataplane_v3.errors import UnexpectedStatus
+from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 from haproxy_template_ic.dataplane import (
-    DataplaneAPIError,
-    ValidationError,
-    DataplaneClient,
     ConfigSynchronizer,
+    DataplaneAPIError,
+    DataplaneClient,
     DeploymentHistory,
+    ValidationError,
+    extract_config_context,
     get_production_urls_from_index,
+    normalize_dataplane_url,
+    parse_haproxy_error_line,
+    parse_validation_error_details,
 )
 from haproxy_template_ic.config_models import HAProxyConfigContext
 
@@ -221,7 +230,6 @@ class TestConfigSynchronizer:
     def test_init(self):
         """Test ConfigSynchronizer initialization."""
         production_urls = ["http://192.168.1.1:5555", "http://192.168.1.2:5555"]
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
         credentials = Credentials(
             dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -238,7 +246,6 @@ class TestConfigSynchronizer:
     @pytest.mark.asyncio
     async def test_sync_configuration_no_rendered_config(self):
         """Test sync with no rendered config."""
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
         credentials = Credentials(
             dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -277,7 +284,6 @@ class TestConfigSynchronizerMethods:
     @pytest.mark.asyncio
     async def test_sync_configuration_validation_failure(self):
         """Test sync with validation failure."""
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
         credentials = Credentials(
             dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -314,7 +320,6 @@ class TestConfigSynchronizerMethods:
     async def test_sync_configuration_mixed_results(self):
         """Test sync with mixed success/failure results."""
         deployment_history = DeploymentHistory()
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
         credentials = Credentials(
             dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -403,35 +408,30 @@ class TestNormalizeDataplaneUrl:
 
     def test_normalize_url_without_v3(self):
         """Test URL normalization adds /v3."""
-        from haproxy_template_ic.dataplane import normalize_dataplane_url
 
         result = normalize_dataplane_url("http://localhost:5555")
         assert result == "http://localhost:5555/v3"
 
     def test_normalize_url_with_trailing_slash(self):
         """Test URL normalization with trailing slash."""
-        from haproxy_template_ic.dataplane import normalize_dataplane_url
 
         result = normalize_dataplane_url("http://localhost:5555/")
         assert result == "http://localhost:5555/v3"
 
     def test_normalize_url_already_has_v3(self):
         """Test URL normalization when /v3 already exists."""
-        from haproxy_template_ic.dataplane import normalize_dataplane_url
 
         result = normalize_dataplane_url("http://localhost:5555/v3")
         assert result == "http://localhost:5555/v3"
 
     def test_normalize_url_with_query_params(self):
         """Test URL normalization preserves query parameters."""
-        from haproxy_template_ic.dataplane import normalize_dataplane_url
 
         result = normalize_dataplane_url("http://localhost:5555?timeout=30")
         assert result == "http://localhost:5555/v3?timeout=30"
 
     def test_normalize_url_with_path_and_query(self):
         """Test URL normalization with existing path and query parameters."""
-        from haproxy_template_ic.dataplane import normalize_dataplane_url
 
         result = normalize_dataplane_url("https://api.example.com/haproxy?auth=token")
         assert result == "https://api.example.com/haproxy/v3?auth=token"
@@ -442,7 +442,6 @@ class TestErrorParsingFunctions:
 
     def test_parse_haproxy_error_line_config_parsing_format(self):
         """Test parsing line number from config parsing error format."""
-        from haproxy_template_ic.dataplane import parse_haproxy_error_line
 
         error_msg = "config parsing [/tmp/onlyvalidate3935728576:54] 'listen' or 'defaults' expected."
         line_num = parse_haproxy_error_line(error_msg)
@@ -450,7 +449,6 @@ class TestErrorParsingFunctions:
 
     def test_parse_haproxy_error_line_simple_line_format(self):
         """Test parsing line number from simple line format."""
-        from haproxy_template_ic.dataplane import parse_haproxy_error_line
 
         error_msg = "line 42: unknown keyword 'foobar'"
         line_num = parse_haproxy_error_line(error_msg)
@@ -458,7 +456,6 @@ class TestErrorParsingFunctions:
 
     def test_parse_haproxy_error_line_at_line_format(self):
         """Test parsing line number from 'at line' format."""
-        from haproxy_template_ic.dataplane import parse_haproxy_error_line
 
         error_msg = "syntax error at line 123"
         line_num = parse_haproxy_error_line(error_msg)
@@ -466,7 +463,6 @@ class TestErrorParsingFunctions:
 
     def test_parse_haproxy_error_line_not_found(self):
         """Test when no line number is found in error message."""
-        from haproxy_template_ic.dataplane import parse_haproxy_error_line
 
         error_msg = "generic error without line number"
         line_num = parse_haproxy_error_line(error_msg)
@@ -474,7 +470,6 @@ class TestErrorParsingFunctions:
 
     def test_extract_config_context(self):
         """Test extracting configuration context around an error line."""
-        from haproxy_template_ic.dataplane import extract_config_context
 
         config = """global
     daemon
@@ -502,7 +497,6 @@ frontend main
 
     def test_extract_config_context_out_of_range(self):
         """Test extracting context when line number is out of range."""
-        from haproxy_template_ic.dataplane import extract_config_context
 
         config = "line1\nline2\nline3"
         context = extract_config_context(config, 10, context_lines=2)
@@ -511,7 +505,6 @@ frontend main
 
     def test_parse_validation_error_details(self):
         """Test parsing complete validation error details."""
-        from haproxy_template_ic.dataplane import parse_validation_error_details
 
         error_msg = "config parsing [/tmp/file:54] 'listen' or 'defaults' expected."
         config = """global
@@ -531,7 +524,6 @@ frontend main
 
     def test_extract_config_context_empty_config(self):
         """Test extracting context from empty configuration."""
-        from haproxy_template_ic.dataplane import extract_config_context
 
         context = extract_config_context("", 1)
         assert context == "No configuration content available"
@@ -541,7 +533,6 @@ frontend main
 
     def test_parse_validation_error_details_context_extraction_exception(self):
         """Test parsing validation error when context extraction fails."""
-        from haproxy_template_ic.dataplane import parse_validation_error_details
 
         error_msg = "config parsing [/tmp/file:2] syntax error"
         config = "global\n    daemon"
@@ -562,7 +553,6 @@ frontend main
 
     def test_parse_haproxy_error_line_invalid_number(self):
         """Test parsing when regex matches but number is invalid."""
-        from haproxy_template_ic.dataplane import parse_haproxy_error_line
 
         # Test with non-numeric match
         error_msg = "config parsing [/tmp/file:invalid]: error"
@@ -706,7 +696,6 @@ class TestConfigSynchronizerSuccessPath:
     async def test_sync_configuration_success(self):
         """Test successful configuration synchronization."""
         deployment_history = DeploymentHistory()
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
         credentials = Credentials(
             dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -887,7 +876,6 @@ class TestDataplaneClientSyncMethods:
     @pytest.mark.asyncio
     async def test_sync_maps_success(self):
         """Test successful map synchronization."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -932,7 +920,6 @@ class TestDataplaneClientSyncMethods:
     @pytest.mark.asyncio
     async def test_sync_maps_with_obsolete_maps(self):
         """Test map sync deletes obsolete maps."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
         mock_api_client = Mock()
@@ -973,7 +960,6 @@ class TestDataplaneClientSyncMethods:
     @pytest.mark.asyncio
     async def test_sync_maps_error_handling(self):
         """Test map sync error handling."""
-        from haproxy_template_ic.dataplane import DataplaneClient, DataplaneAPIError
 
         client = DataplaneClient("http://localhost:5555")
         mock_api_client = Mock()
@@ -995,7 +981,6 @@ class TestDataplaneClientSyncMethods:
     @pytest.mark.asyncio
     async def test_sync_certificates_success(self):
         """Test successful certificate synchronization."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
         mock_api_client = Mock()
@@ -1037,7 +1022,6 @@ class TestDataplaneClientSyncMethods:
     @pytest.mark.asyncio
     async def test_sync_certificates_error_handling(self):
         """Test certificate sync error handling."""
-        from haproxy_template_ic.dataplane import DataplaneClient, DataplaneAPIError
 
         client = DataplaneClient("http://localhost:5555")
         mock_api_client = Mock()
@@ -1061,7 +1045,6 @@ class TestDataplaneClientSyncMethods:
     @pytest.mark.asyncio
     async def test_sync_files_success(self):
         """Test successful general file synchronization."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
         mock_api_client = Mock()
@@ -1109,7 +1092,6 @@ class TestDataplaneClientSyncMethods:
     @pytest.mark.asyncio
     async def test_sync_files_error_handling(self):
         """Test file sync error handling."""
-        from haproxy_template_ic.dataplane import DataplaneClient, DataplaneAPIError
 
         client = DataplaneClient("http://localhost:5555")
         mock_api_client = Mock()
@@ -1133,7 +1115,6 @@ class TestDataplaneClientSyncMethods:
     @pytest.mark.asyncio
     async def test_sync_maps_with_none_response(self):
         """Test sync_maps handles None response from API."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
         mock_api_client = Mock()
@@ -1160,7 +1141,6 @@ class TestDataplaneClientSyncMethods:
     @pytest.mark.asyncio
     async def test_sync_certificates_with_none_response(self):
         """Test sync_certificates handles None response from API."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
         mock_api_client = Mock()
@@ -1187,7 +1167,6 @@ class TestDataplaneClientSyncMethods:
     @pytest.mark.asyncio
     async def test_sync_files_with_none_response(self):
         """Test sync_files handles None response from API."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
         mock_api_client = Mock()
@@ -1217,7 +1196,6 @@ class TestDataplaneCriticalPaths:
 
     def test_normalize_dataplane_url_malformed_urls(self):
         """Test URL normalization with malformed URLs."""
-        from haproxy_template_ic.dataplane import normalize_dataplane_url
 
         # Test malformed scheme
         malformed_scheme_url = "htp://localhost:5555"  # typo in http
@@ -1246,7 +1224,6 @@ class TestDataplaneCriticalPaths:
 
     def test_normalize_dataplane_url_parse_errors(self):
         """Test URL normalization with parsing errors triggering fallbacks."""
-        from haproxy_template_ic.dataplane import normalize_dataplane_url
 
         # Test with string that causes urlparse to raise ValueError
         with patch("haproxy_template_ic.dataplane.urlparse") as mock_urlparse:
@@ -1262,7 +1239,6 @@ class TestDataplaneCriticalPaths:
 
     def test_normalize_dataplane_url_reconstruction_errors(self):
         """Test URL normalization when urlunparse fails."""
-        from haproxy_template_ic.dataplane import normalize_dataplane_url
 
         with patch("haproxy_template_ic.dataplane.urlunparse") as mock_urlunparse:
             mock_urlunparse.side_effect = ValueError("URL reconstruction failed")
@@ -1274,7 +1250,6 @@ class TestDataplaneCriticalPaths:
     @pytest.mark.asyncio
     async def test_dataplane_client_get_version_success(self):
         """Test DataplaneClient.get_version() successful retrieval."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -1306,8 +1281,6 @@ class TestDataplaneCriticalPaths:
     @pytest.mark.asyncio
     async def test_dataplane_client_get_version_api_exception(self):
         """Test DataplaneClient.get_version() API exception handling."""
-        from haproxy_template_ic.dataplane import DataplaneClient, DataplaneAPIError
-        from haproxy_dataplane_v3.errors import UnexpectedStatus
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -1325,7 +1298,6 @@ class TestDataplaneCriticalPaths:
     @pytest.mark.asyncio
     async def test_dataplane_client_get_version_network_errors(self):
         """Test DataplaneClient.get_version() network error handling."""
-        from haproxy_template_ic.dataplane import DataplaneClient, DataplaneAPIError
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -1360,7 +1332,6 @@ class TestDataplaneCriticalPaths:
     @pytest.mark.asyncio
     async def test_dataplane_client_get_version_unexpected_exception(self):
         """Test DataplaneClient.get_version() unexpected exception handling."""
-        from haproxy_template_ic.dataplane import DataplaneClient, DataplaneAPIError
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -1376,7 +1347,6 @@ class TestDataplaneCriticalPaths:
     @pytest.mark.asyncio
     async def test_validate_configuration_success(self):
         """Test successful configuration validation."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -1397,7 +1367,6 @@ class TestDataplaneCriticalPaths:
     @pytest.mark.asyncio
     async def test_validate_configuration_bad_request_exception(self):
         """Test configuration validation with bad request response."""
-        from haproxy_template_ic.dataplane import DataplaneClient, ValidationError
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -1423,7 +1392,6 @@ class TestDataplaneCriticalPaths:
     @pytest.mark.asyncio
     async def test_validate_configuration_network_errors(self):
         """Test configuration validation network error handling."""
-        from haproxy_template_ic.dataplane import DataplaneClient, DataplaneAPIError
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -1433,7 +1401,6 @@ class TestDataplaneCriticalPaths:
             mock_httpx_client.return_value.__aenter__.return_value = (
                 mock_client_instance
             )
-            import httpx
 
             mock_client_instance.post.side_effect = httpx.RequestError("Network error")
 
@@ -1446,7 +1413,6 @@ class TestDataplaneCriticalPaths:
     @pytest.mark.asyncio
     async def test_validate_configuration_unexpected_exception(self):
         """Test configuration validation unexpected exception handling."""
-        from haproxy_template_ic.dataplane import DataplaneClient, DataplaneAPIError
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -1466,7 +1432,6 @@ class TestDataplaneCriticalPaths:
     @pytest.mark.asyncio
     async def test_deploy_configuration_success(self):
         """Test successful configuration deployment."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -1502,7 +1467,6 @@ class TestDataplaneCriticalPaths:
     @pytest.mark.asyncio
     async def test_deploy_configuration_error_with_context(self):
         """Test deployment error includes HAProxy config context."""
-        from haproxy_template_ic.dataplane import DataplaneClient, DataplaneAPIError
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -1559,7 +1523,6 @@ class TestConfigSynchronizerSyncMethods:
     async def test_sync_configuration_with_maps_and_certificates(self):
         """Test sync with maps and certificates."""
         deployment_history = DeploymentHistory()
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
         credentials = Credentials(
             dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -1645,7 +1608,6 @@ class TestConfigSynchronizerSyncMethods:
     async def test_sync_configuration_deployment_with_config_context_error(self):
         """Test deployment error with config context parsing."""
         deployment_history = DeploymentHistory()
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
         credentials = Credentials(
             dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -1730,8 +1692,6 @@ defaults
     ):
         """Test deployment error with DataplaneAPIError that already contains context."""
         deployment_history = DeploymentHistory()
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
-        from haproxy_template_ic.dataplane import DataplaneAPIError
 
         credentials = Credentials(
             dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -1808,7 +1768,6 @@ defaults
     async def test_sync_configuration_deployment_context_extraction_failure(self):
         """Test deployment error when context extraction fails."""
         deployment_history = DeploymentHistory()
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
         credentials = Credentials(
             dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -1893,7 +1852,6 @@ class TestDataplaneClientDeploymentRetryLogic:
     @pytest.mark.asyncio
     async def test_deploy_configuration_version_get_failure(self):
         """Test deployment when getting current version fails."""
-        from haproxy_template_ic.dataplane import DataplaneClient, DataplaneAPIError
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -1919,7 +1877,6 @@ class TestDataplaneClientDeploymentRetryLogic:
     @pytest.mark.asyncio
     async def test_deploy_configuration_new_version_get_failure(self):
         """Test deployment when getting new version after deployment fails."""
-        from haproxy_template_ic.dataplane import DataplaneClient, DataplaneAPIError
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -1957,7 +1914,6 @@ class TestDataplaneClientDeploymentRetryLogic:
     @pytest.mark.asyncio
     async def test_deploy_configuration_successful(self):
         """Test successful configuration deployment."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -1992,8 +1948,6 @@ class TestDataplaneClientDeploymentRetryLogic:
     @pytest.mark.asyncio
     async def test_deploy_configuration_retry_exhausted(self):
         """Test deployment when all retry attempts are exhausted."""
-        from haproxy_template_ic.dataplane import DataplaneClient, DataplaneAPIError
-        import httpx
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -2025,7 +1979,6 @@ class TestConditionalDeployment:
     @pytest.mark.asyncio
     async def test_get_current_configuration_success(self):
         """Test successful retrieval of current configuration."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -2047,7 +2000,6 @@ class TestConditionalDeployment:
     @pytest.mark.asyncio
     async def test_get_current_configuration_error(self):
         """Test handling of errors when getting current configuration."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -2068,7 +2020,6 @@ class TestConditionalDeployment:
     @pytest.mark.asyncio
     async def test_deploy_configuration_conditionally_config_unchanged(self):
         """Test conditional deployment when configuration is unchanged."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
         current_config = "global\n    daemon\n"
@@ -2097,7 +2048,6 @@ class TestConditionalDeployment:
     @pytest.mark.asyncio
     async def test_deploy_configuration_conditionally_config_changed(self):
         """Test conditional deployment when configuration has changed."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
         current_config = "global\n    daemon\n"
@@ -2118,7 +2068,6 @@ class TestConditionalDeployment:
     @pytest.mark.asyncio
     async def test_deploy_configuration_conditionally_force_deployment(self):
         """Test conditional deployment with force=True."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
         config = "global\n    daemon\n"
@@ -2135,7 +2084,6 @@ class TestConditionalDeployment:
     @pytest.mark.asyncio
     async def test_deploy_configuration_conditionally_no_current_config(self):
         """Test conditional deployment when current config is not available."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
         new_config = "global\n    daemon\n"
@@ -2154,7 +2102,6 @@ class TestConditionalDeployment:
 
     def test_config_normalization(self):
         """Test configuration normalization for comparison."""
-        from haproxy_template_ic.dataplane import DataplaneClient
 
         client = DataplaneClient("http://localhost:5555")
 
@@ -2167,8 +2114,6 @@ class TestConditionalDeployment:
                 # All should normalize to the same thing
                 mock_get_current.return_value = config1
                 mock_deploy.return_value = "9"
-
-                import asyncio
 
                 # The normalization logic is embedded in the method,
                 # so we test it indirectly by ensuring identical normalized configs are detected
@@ -2199,9 +2144,6 @@ class TestConfigSynchronizerEnhancements:
     @pytest.mark.asyncio
     async def test_sync_configuration_with_skipped_deployments(self):
         """Test sync_configuration with some deployments skipped due to unchanged config."""
-        from haproxy_template_ic.dataplane import ConfigSynchronizer
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
-        from pydantic import SecretStr
 
         # Setup test data
         production_urls = ["http://prod1:5555", "http://prod2:5555"]
@@ -2307,9 +2249,6 @@ class TestConfigSynchronizerEnhancements:
     @pytest.mark.asyncio
     async def test_sync_configuration_with_fallback_deployment(self):
         """Test sync_configuration with fallback to regular deployment when conditional fails."""
-        from haproxy_template_ic.dataplane import ConfigSynchronizer
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
-        from pydantic import SecretStr
 
         # Setup test data
         production_urls = ["http://prod1:5555"]

--- a/tests/unit/test_dataplane_simple.py
+++ b/tests/unit/test_dataplane_simple.py
@@ -16,6 +16,7 @@ from haproxy_template_ic.dataplane import (
     get_production_urls_from_index,
     normalize_dataplane_url,
 )
+from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
 
 class TestNormalizeDataplaneUrlComplete:
@@ -184,7 +185,6 @@ class TestConfigSynchronizerSimple:
 
     def test_synchronizer_initialization(self):
         """Test synchronizer initialization."""
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
         credentials = Credentials(
             dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -206,7 +206,6 @@ class TestConfigSynchronizerSimple:
     @pytest.mark.asyncio
     async def test_sync_configuration_no_rendered_config(self):
         """Test sync with no rendered config."""
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
         credentials = Credentials(
             dataplane=DataplaneAuth(username="admin", password="adminpass"),

--- a/tests/unit/test_field_filter.py
+++ b/tests/unit/test_field_filter.py
@@ -8,6 +8,7 @@ import copy
 from unittest.mock import patch, MagicMock
 
 from haproxy_template_ic.field_filter import (
+    _remove_field_at_path,
     remove_fields_from_resource,
     validate_ignore_fields,
 )
@@ -273,7 +274,6 @@ class TestFieldFilter:
 
     def test_match_without_parts(self):
         """Test _remove_field_at_path with match lacking parts attribute."""
-        from haproxy_template_ic.field_filter import _remove_field_at_path
 
         resource = {"metadata": {"name": "test"}}
 
@@ -286,7 +286,6 @@ class TestFieldFilter:
 
     def test_empty_parts_in_match(self):
         """Test _remove_field_at_path with empty parts list."""
-        from haproxy_template_ic.field_filter import _remove_field_at_path
 
         resource = {"metadata": {"name": "test"}}
 
@@ -304,7 +303,6 @@ class TestFieldFilter:
 
     def test_path_not_in_dict(self):
         """Test navigation when path doesn't exist in dict."""
-        from haproxy_template_ic.field_filter import _remove_field_at_path
 
         resource = {"metadata": {"name": "test"}}
 
@@ -317,7 +315,6 @@ class TestFieldFilter:
 
     def test_list_navigation_errors(self):
         """Test errors during list navigation."""
-        from haproxy_template_ic.field_filter import _remove_field_at_path
 
         resource = {"items": ["a", "b", "c"]}
 
@@ -347,7 +344,6 @@ class TestFieldFilter:
 
     def test_nested_list_navigation(self):
         """Test complex list navigation scenarios."""
-        from haproxy_template_ic.field_filter import _remove_field_at_path
 
         # Test navigating through nested structures with lists
         resource = {
@@ -378,7 +374,6 @@ class TestFieldFilter:
 
     def test_final_part_list_errors(self):
         """Test errors when removing final part from list."""
-        from haproxy_template_ic.field_filter import _remove_field_at_path
 
         resource = {"items": ["a", "b", "c"]}
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -5,11 +5,14 @@ This module contains tests for CLI functionality and main application entry poin
 with the simplified CLI structure (run command only).
 """
 
+import click
 import pytest
+from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 from click.testing import CliRunner
 
 from haproxy_template_ic.__main__ import cli
+from haproxy_template_ic.credentials import validate_k8s_name
 
 
 # =============================================================================
@@ -261,8 +264,6 @@ def test_run_command_valid_configmap_names(mock_shutdown, mock_init, mock_run):
 
 def test_configmap_validation_edge_cases():
     """Test unified Kubernetes name validation edge cases."""
-    from haproxy_template_ic.credentials import validate_k8s_name
-    import click
 
     # Test maximum length (253 characters)
     valid_long_name = "a" * 253
@@ -307,7 +308,6 @@ def test_version_command():
 @patch("haproxy_template_ic.__main__.metadata.version")
 def test_version_command_development_fallback(mock_version):
     """Test version command fallback when package not found."""
-    from importlib.metadata import PackageNotFoundError
 
     mock_version.side_effect = PackageNotFoundError()
     runner = CliRunner()

--- a/tests/unit/test_management_socket.py
+++ b/tests/unit/test_management_socket.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock, AsyncMock, patch
 
 from haproxy_template_ic.management_socket import (
     ManagementSocketServer,
+    _serialize_resource_collection,
     serialize_state,
     run_management_socket_server,
     _serialize_kopf_index,
@@ -884,7 +885,6 @@ class TestManagementSocketCriticalPaths:
 
     def test_serialize_resource_collection_dict_fallback(self):
         """Test _serialize_resource_collection fallback for dicts (line 58)."""
-        from haproxy_template_ic.management_socket import _serialize_resource_collection
 
         # Test with a single dict resource - dicts are iterable so they iterate over keys
         resource_dict = {"name": "test-resource", "status": "active"}
@@ -899,7 +899,6 @@ class TestManagementSocketCriticalPaths:
 
     def test_serialize_state_metadata_serialization_error(self):
         """Test serialize_state metadata serialization error (lines 162-164)."""
-        from haproxy_template_ic.management_socket import serialize_state
 
         memo = Mock()
         memo.config = Mock()
@@ -928,7 +927,6 @@ class TestManagementSocketCriticalPaths:
 
     def test_serialize_state_cli_options_serialization_error(self):
         """Test serialize_state CLI options serialization error (lines 177-179)."""
-        from haproxy_template_ic.management_socket import serialize_state
 
         memo = Mock()
         memo.config = Mock()

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -4,6 +4,7 @@ Tests for haproxy_template_ic.metrics module.
 This module contains tests for Prometheus metrics collection functionality.
 """
 
+import threading
 import time
 from unittest.mock import patch
 
@@ -308,7 +309,6 @@ class TestMetricsIntegration:
 
     def test_concurrent_metrics_recording(self):
         """Test that metrics recording is thread-safe."""
-        import threading
 
         collector = get_metrics_collector()
 

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -6,15 +6,22 @@ critical paths and edge cases that are likely to detect bugs.
 """
 
 import asyncio
+import logging
+import os
+import shutil
+import tempfile
+import time
 import kopf
 import pytest
 import yaml
 from jinja2 import Template
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+from haproxy_template_ic.__main__ import CliOptions
 from haproxy_template_ic.config_models import (
     Config,
     HAProxyConfigContext,
+    IndexedResourceCollection,
     PodSelector,
     RenderedContent,
     RenderedConfig,
@@ -23,20 +30,34 @@ from haproxy_template_ic.config_models import (
     WatchResourceConfig,
     config_from_dict,
 )
+from haproxy_template_ic.credentials import Credentials, DataplaneAuth
+from haproxy_template_ic.dataplane import DataplaneAPIError, ValidationError
 from haproxy_template_ic.operator import (
+    _collect_resource_indices,
+    _get_haproxy_pod_collection,
     _is_valid_resource,
     _is_valid_dict_resource,
     _is_valid_sequence_resource,
     _is_valid_object_resource,
+    _log_haproxy_error_hints,
+    configure_webhook_server,
     create_operator_memo,
+    extract_nested_field,
     fetch_configmap,
     fetch_secret,
     get_current_namespace,
     handle_configmap_change,
+    handle_haproxy_pod_create,
+    handle_secret_change,
     haproxy_pods_index,
+    init_management_socket,
+    init_metrics_server,
+    init_watch_configmap,
     initialize_configuration,
     load_config_from_configmap,
     render_haproxy_templates,
+    run_operator_loop,
+    setup_haproxy_pod_indexing,
     setup_resource_watchers,
     synchronize_with_haproxy_instances,
     trigger_reload,
@@ -735,7 +756,6 @@ async def test_synchronize_with_haproxy_instances_success(
     memo = MagicMock()
     memo.config.pod_selector = PodSelector(match_labels={"app": "haproxy"})
     # Set up credentials in memo (no longer in config)
-    from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
     memo.credentials = Credentials(
         dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -776,7 +796,6 @@ async def test_synchronize_with_haproxy_instances_success(
     # Verify the argument is an IndexedResourceCollection
     call_args = mock_get_urls.call_args[0]
     assert len(call_args) == 1
-    from haproxy_template_ic.config_models import IndexedResourceCollection
 
     assert isinstance(call_args[0], IndexedResourceCollection)
     mock_synchronizer_class.assert_called_once_with(
@@ -822,12 +841,10 @@ async def test_synchronize_with_haproxy_instances_validation_error(
     mock_synchronizer_class, mock_get_urls
 ):
     """Test synchronization handling validation errors."""
-    from haproxy_template_ic.dataplane import ValidationError
 
     memo = MagicMock()
     memo.config.pod_selector = PodSelector(match_labels={"app": "haproxy"})
     # Set up credentials in memo (no longer in config)
-    from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
     memo.credentials = Credentials(
         dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -861,7 +878,6 @@ async def test_synchronize_with_haproxy_instances_with_failures(
     memo = MagicMock()
     memo.config.pod_selector = PodSelector(match_labels={"app": "haproxy"})
     # Set up credentials in memo (no longer in config)
-    from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
     memo.credentials = Credentials(
         dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -898,7 +914,6 @@ async def test_synchronize_with_haproxy_instances_with_failures(
 
 def test_create_operator_memo():
     """Test operator memo creation."""
-    from haproxy_template_ic.__main__ import CliOptions
 
     cli_options = CliOptions(
         configmap_name="test-config",
@@ -1003,7 +1018,6 @@ async def test_initialize_configuration(
     mock_get_namespace,
 ):
     """Test initialize_configuration function."""
-    from haproxy_template_ic.__main__ import CliOptions
 
     # Set up mocks
     mock_get_namespace.return_value = "test-namespace"
@@ -1022,7 +1036,6 @@ async def test_initialize_configuration(
     }
     mock_fetch_secret.return_value = mock_secret
     # Set up credentials mock
-    from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
     mock_credentials = Credentials(
         dataplane=DataplaneAuth(username="admin", password="pass"),
@@ -1131,7 +1144,6 @@ class TestSynchronizeErrorPaths:
         memo = MagicMock()
         memo.config.pod_selector = PodSelector(match_labels={"app": "haproxy"})
         # Set up credentials in memo (no longer in config)
-        from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
         memo.credentials = Credentials(
             dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -1483,7 +1495,6 @@ async def test_synchronize_success_and_failure_logging(
     memo = MagicMock()
     memo.config.pod_selector = PodSelector(match_labels={"app": "haproxy"})
     # Set up credentials in memo (no longer in config)
-    from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
     memo.credentials = Credentials(
         dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -1523,12 +1534,10 @@ async def test_synchronize_dataplane_api_error(
     mock_logger, mock_synchronizer_class, mock_get_urls
 ):
     """Test DataplaneAPIError handling in synchronization."""
-    from haproxy_template_ic.dataplane import DataplaneAPIError
 
     memo = MagicMock()
     memo.config.pod_selector = PodSelector(match_labels={"app": "haproxy"})
     # Set up credentials in memo (no longer in config)
-    from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
     memo.credentials = Credentials(
         dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -1566,7 +1575,6 @@ async def test_initialize_configuration_failure(
     mock_logger, mock_load_config, mock_fetch_configmap, mock_get_namespace
 ):
     """Test initialize_configuration failure handling."""
-    from haproxy_template_ic.__main__ import CliOptions
 
     # Set up failure scenario
     mock_get_namespace.return_value = "test-namespace"
@@ -1600,8 +1608,6 @@ async def test_initialize_configuration_failure(
 @patch("haproxy_template_ic.operator.get_current_namespace")
 async def test_init_watch_configmap(mock_get_namespace, mock_event):
     """Test init_watch_configmap startup handler."""
-    from haproxy_template_ic.operator import init_watch_configmap
-    from haproxy_template_ic.__main__ import CliOptions
 
     memo = MagicMock()
     cli_options = CliOptions(
@@ -1640,8 +1646,6 @@ async def test_init_watch_configmap(mock_get_namespace, mock_event):
 @patch("haproxy_template_ic.operator.run_management_socket_server")
 async def test_init_management_socket(mock_run_socket, mock_create_task):
     """Test init_management_socket startup handler."""
-    from haproxy_template_ic.operator import init_management_socket
-    from haproxy_template_ic.__main__ import CliOptions
 
     memo = MagicMock()
     cli_options = CliOptions(
@@ -1671,8 +1675,6 @@ async def test_init_management_socket(mock_run_socket, mock_create_task):
 @patch("haproxy_template_ic.operator.get_metrics_collector")
 async def test_init_metrics_server(mock_get_metrics, mock_create_task):
     """Test init_metrics_server startup handler."""
-    from haproxy_template_ic.operator import init_metrics_server
-    from haproxy_template_ic.__main__ import CliOptions
 
     memo = MagicMock()
     cli_options = CliOptions(
@@ -1717,7 +1719,6 @@ async def test_init_metrics_server(mock_get_metrics, mock_create_task):
 @patch("haproxy_template_ic.operator.logger")
 def test_configure_webhook_server_no_webhooks(mock_logger):
     """Test webhook server configuration with no webhooks enabled."""
-    from haproxy_template_ic.operator import configure_webhook_server
 
     settings = MagicMock()
     memo = MagicMock()
@@ -1742,7 +1743,6 @@ def test_configure_webhook_server_with_existing_certs(
     mock_logger, mock_mkdtemp, mock_exists
 ):
     """Test webhook server configuration with existing TLS certificates."""
-    from haproxy_template_ic.operator import configure_webhook_server
 
     settings = MagicMock()
     memo = MagicMock()
@@ -1774,7 +1774,6 @@ def test_configure_webhook_server_with_existing_certs(
 @patch("haproxy_template_ic.operator.logger")
 def test_configure_webhook_server_self_signed(mock_logger, mock_mkdtemp, mock_exists):
     """Test webhook server configuration with self-signed certificates."""
-    from haproxy_template_ic.operator import configure_webhook_server
 
     settings = MagicMock()
     memo = MagicMock()
@@ -1817,8 +1816,6 @@ def test_run_operator_loop_normal_shutdown(
     mock_kopf_run,
 ):
     """Test run_operator_loop with normal shutdown."""
-    from haproxy_template_ic.operator import run_operator_loop
-    from haproxy_template_ic.__main__ import CliOptions
 
     # Mock dependencies
     mock_metrics = MagicMock()
@@ -1895,8 +1892,6 @@ def test_run_operator_loop_with_config_reload(
     mock_kopf_run,
 ):
     """Test run_operator_loop with config reload scenario."""
-    from haproxy_template_ic.operator import run_operator_loop
-    from haproxy_template_ic.__main__ import CliOptions
 
     # Mock dependencies
     mock_metrics = MagicMock()
@@ -1963,7 +1958,6 @@ def test_run_operator_loop_with_config_reload(
 
 def test_extract_nested_field_basic_access():
     """Test extract_nested_field with basic dot notation access."""
-    from haproxy_template_ic.operator import extract_nested_field
 
     obj = {"metadata": {"name": "test-pod", "namespace": "default"}}
 
@@ -1978,7 +1972,6 @@ def test_extract_nested_field_basic_access():
 
 def test_extract_nested_field_bracket_notation():
     """Test extract_nested_field with bracket notation for keys with special chars."""
-    from haproxy_template_ic.operator import extract_nested_field
 
     obj = {
         "metadata": {
@@ -2013,7 +2006,6 @@ def test_extract_nested_field_bracket_notation():
 
 def test_extract_nested_field_malformed_brackets():
     """Test extract_nested_field with malformed bracket notation."""
-    from haproxy_template_ic.operator import extract_nested_field
 
     obj = {"metadata": {"labels": {"app": "test"}}}
 
@@ -2030,7 +2022,6 @@ def test_extract_nested_field_malformed_brackets():
 
 def test_extract_nested_field_non_dict_objects():
     """Test extract_nested_field with non-dict current values."""
-    from haproxy_template_ic.operator import extract_nested_field
 
     obj = {
         "metadata": "not-a-dict",
@@ -2049,7 +2040,6 @@ def test_extract_nested_field_non_dict_objects():
 
 def test_extract_nested_field_none_values():
     """Test extract_nested_field with None values."""
-    from haproxy_template_ic.operator import extract_nested_field
 
     obj = {"metadata": {"name": None, "labels": {"app": None}}}
 
@@ -2060,7 +2050,6 @@ def test_extract_nested_field_none_values():
 
 def test_extract_nested_field_never_returns_dict_as_string():
     """Test that extract_nested_field never returns dict/list as string."""
-    from haproxy_template_ic.operator import extract_nested_field
 
     obj = {
         "metadata": {
@@ -2088,7 +2077,6 @@ def test_extract_nested_field_never_returns_dict_as_string():
 
 def test_extract_nested_field_edge_cases():
     """Test extract_nested_field with various edge cases."""
-    from haproxy_template_ic.operator import extract_nested_field
 
     # Test with Unicode keys
     obj_unicode = {
@@ -2154,7 +2142,6 @@ def test_extract_nested_field_edge_cases():
 
 def test_extract_nested_field_array_indexing():
     """Test extract_nested_field with array indexing."""
-    from haproxy_template_ic.operator import extract_nested_field
 
     obj = {
         "spec": {
@@ -2180,7 +2167,6 @@ def test_extract_nested_field_array_indexing():
 
 def test_extract_nested_field_input_validation():
     """Test extract_nested_field input validation."""
-    from haproxy_template_ic.operator import extract_nested_field
 
     obj = {"metadata": {"name": "test"}}
 
@@ -2202,8 +2188,6 @@ def test_extract_nested_field_input_validation():
 
 def test_extract_nested_field_performance():
     """Benchmark extract_nested_field performance with typical Kubernetes resources."""
-    import time
-    from haproxy_template_ic.operator import extract_nested_field
 
     # Create a realistic Kubernetes resource
     resource = {
@@ -2275,8 +2259,6 @@ def test_extract_nested_field_performance():
 @pytest.mark.asyncio
 async def test_update_resource_index_no_memo():
     """Test update_resource_index without memo object."""
-    import logging
-    from haproxy_template_ic.operator import update_resource_index
 
     body = {"metadata": {"namespace": "test-ns", "name": "test-resource"}}
 
@@ -2295,8 +2277,6 @@ async def test_update_resource_index_no_memo():
 @pytest.mark.asyncio
 async def test_update_resource_index_no_config():
     """Test update_resource_index with memo but no config."""
-    import logging
-    from haproxy_template_ic.operator import update_resource_index
 
     # Mock memo without config
     memo = MagicMock()
@@ -2320,8 +2300,6 @@ async def test_update_resource_index_no_config():
 @pytest.mark.asyncio
 async def test_update_resource_index_custom_indexing():
     """Test update_resource_index with custom index_by configuration."""
-    import logging
-    from haproxy_template_ic.operator import update_resource_index
 
     # Mock memo with watch config
     memo = MagicMock()
@@ -2353,8 +2331,6 @@ async def test_update_resource_index_custom_indexing():
 @pytest.mark.asyncio
 async def test_update_resource_index_missing_fields():
     """Test update_resource_index with missing index fields."""
-    import logging
-    from haproxy_template_ic.operator import update_resource_index
 
     # Mock memo with watch config
     memo = MagicMock()
@@ -2418,7 +2394,6 @@ async def test_render_haproxy_templates_empty_index():
 @patch("haproxy_template_ic.operator.ConfigSynchronizer")
 async def test_synchronize_mixed_results_logging(mock_sync_class, mock_get_urls):
     """Test synchronize_with_haproxy_instances with mixed success and failure results."""
-    from haproxy_template_ic.operator import synchronize_with_haproxy_instances
 
     with patch("haproxy_template_ic.operator.get_metrics_collector"):
         with patch("haproxy_template_ic.operator.logger"):
@@ -2426,7 +2401,6 @@ async def test_synchronize_mixed_results_logging(mock_sync_class, mock_get_urls)
             memo = MagicMock()
             memo.config.pod_selector = MagicMock()
             # Set up credentials in memo (no longer in config)
-            from haproxy_template_ic.credentials import Credentials, DataplaneAuth
 
             memo.credentials = Credentials(
                 dataplane=DataplaneAuth(username="admin", password="adminpass"),
@@ -2464,7 +2438,6 @@ async def test_synchronize_mixed_results_logging(mock_sync_class, mock_get_urls)
 
 def test_configure_webhook_server_ca_file_copying():
     """Test configure_webhook_server CA file copying functionality."""
-    from haproxy_template_ic.operator import configure_webhook_server
 
     with patch("os.path.exists") as mock_exists:
         with patch("tempfile.mkdtemp", return_value="/tmp/webhook-ca-123"):
@@ -2504,7 +2477,6 @@ def test_configure_webhook_server_ca_file_copying():
 
 def test_configure_webhook_server_no_ca_file():
     """Test configure_webhook_server without existing CA file."""
-    from haproxy_template_ic.operator import configure_webhook_server
 
     with patch("os.path.exists") as mock_exists:
         with patch("tempfile.mkdtemp", return_value="/tmp/webhook-ca-456"):
@@ -2613,7 +2585,6 @@ async def test_haproxy_pods_index_no_metadata():
 @pytest.mark.asyncio
 async def test_handle_haproxy_pod_create():
     """Test haproxy pod create handler."""
-    from haproxy_template_ic.operator import handle_haproxy_pod_create
 
     body = {"metadata": {"name": "test-pod", "namespace": "test-namespace"}}
 
@@ -2625,7 +2596,6 @@ async def test_handle_haproxy_pod_create():
 
 def test_setup_haproxy_pod_indexing():
     """Test HAProxy pod indexing setup."""
-    from haproxy_template_ic.operator import setup_haproxy_pod_indexing
 
     memo = MagicMock()
     memo.config.pod_selector.match_labels = {
@@ -2647,7 +2617,6 @@ def test_setup_haproxy_pod_indexing():
 
 def test_setup_resource_watchers_additional():
     """Test resource watchers setup with additional scenarios."""
-    from haproxy_template_ic.operator import setup_resource_watchers
 
     memo = MagicMock()
     watch_config = MagicMock()
@@ -2668,7 +2637,6 @@ def test_setup_resource_watchers_additional():
 
 def test_setup_resource_watchers_no_group():
     """Test resource watchers setup without group/version."""
-    from haproxy_template_ic.operator import setup_resource_watchers
 
     memo = MagicMock()
     watch_config = MagicMock()
@@ -2690,7 +2658,6 @@ def test_setup_resource_watchers_no_group():
 @pytest.mark.asyncio
 async def test_fetch_secret():
     """Test secret fetching."""
-    from haproxy_template_ic.operator import fetch_secret
 
     mock_secret = MagicMock()
 
@@ -2707,7 +2674,6 @@ async def test_fetch_secret():
 @pytest.mark.asyncio
 async def test_fetch_secret_failure():
     """Test secret fetching failure."""
-    from haproxy_template_ic.operator import fetch_secret
 
     with patch("haproxy_template_ic.operator.Secret") as mock_secret_class:
         mock_secret_class.get = AsyncMock(side_effect=Exception("Secret not found"))
@@ -2719,7 +2685,6 @@ async def test_fetch_secret_failure():
 @pytest.mark.asyncio
 async def test_handle_secret_change():
     """Test secret change handling."""
-    from haproxy_template_ic.operator import handle_secret_change
 
     memo = MagicMock()
     memo.credentials = MagicMock()
@@ -2747,7 +2712,6 @@ async def test_handle_secret_change():
 
 def test_trigger_reload_additional():
     """Test trigger reload function with additional coverage."""
-    from haproxy_template_ic.operator import trigger_reload
 
     memo = MagicMock()
     memo.config_reload_flag = MagicMock()
@@ -2761,7 +2725,6 @@ def test_trigger_reload_additional():
 
 def test_is_valid_resource():
     """Test resource validation."""
-    from haproxy_template_ic.operator import _is_valid_resource
 
     # Valid dict resource
     valid_dict = {"metadata": {"name": "test", "namespace": "default"}}
@@ -2892,7 +2855,6 @@ class TestOperatorCriticalPaths:
     @pytest.mark.asyncio
     async def test_handle_secret_change_credential_loading_failures(self):
         """Test handle_secret_change credential loading failures (lines 263-265)."""
-        from haproxy_template_ic.operator import handle_secret_change
 
         memo = MagicMock()
         memo.credentials = None
@@ -2919,7 +2881,6 @@ class TestOperatorCriticalPaths:
 
     def test_extract_nested_field_malformed_bracket_notation(self):
         """Test extract_nested_field with malformed bracket notation."""
-        from haproxy_template_ic.operator import extract_nested_field
 
         obj = {"metadata": {"labels": {"app": "test"}}}
 
@@ -3058,7 +3019,6 @@ class TestOperatorCriticalPaths:
 
     def test_configure_webhook_server_cleanup_edge_cases(self):
         """Test webhook server cleanup edge cases (lines 850-857)."""
-        from haproxy_template_ic.operator import configure_webhook_server
 
         # Mock memo with webhook-enabled resources
         memo = MagicMock()
@@ -3334,8 +3294,6 @@ class TestOperatorErrorPaths:
 
     def test_get_haproxy_pod_collection_memo_no_indices(self):
         """Test _get_haproxy_pod_collection when memo has no indices attribute."""
-        from haproxy_template_ic.operator import _get_haproxy_pod_collection
-        from unittest.mock import patch
 
         # Create memo without indices attribute
         mock_memo = Mock()
@@ -3351,7 +3309,6 @@ class TestOperatorErrorPaths:
 
     def test_extract_nested_field_bracket_notation_exception(self):
         """Test extract_nested_field with malformed bracket notation causing exceptions."""
-        from haproxy_template_ic.operator import extract_nested_field
 
         test_resource = {"metadata": {"labels": {"app": "test"}}}
 
@@ -3368,9 +3325,6 @@ class TestOperatorErrorPaths:
 
     def test_collect_resource_indices_exception(self):
         """Test _collect_resource_indices when index retrieval raises exception."""
-        from haproxy_template_ic.operator import _collect_resource_indices
-        from haproxy_template_ic.config_models import IndexedResourceCollection
-        from unittest.mock import patch, MagicMock
 
         # Create mock memo with indices
         mock_memo = Mock()
@@ -3401,7 +3355,6 @@ class TestOperatorErrorPaths:
     @pytest.mark.asyncio
     async def test_handle_configmap_change_validation_errors_warning(self):
         """Test handle_configmap_change logs warning when validation errors exist."""
-        from unittest.mock import patch
 
         mock_memo = Mock()
         mock_memo.config = Mock()
@@ -3432,9 +3385,6 @@ class TestOperatorErrorPaths:
 
     def test_log_haproxy_error_hints_with_error_line(self):
         """Test _log_haproxy_error_hints with error_line set."""
-        from haproxy_template_ic.operator import _log_haproxy_error_hints
-        from haproxy_template_ic.dataplane import ValidationError
-        from unittest.mock import patch
 
         mock_memo = Mock()
         mock_memo.config = Mock()
@@ -3458,9 +3408,6 @@ class TestOperatorErrorPaths:
 
     def test_log_haproxy_error_hints_with_error_context(self):
         """Test _log_haproxy_error_hints with error_context set."""
-        from haproxy_template_ic.operator import _log_haproxy_error_hints
-        from haproxy_template_ic.dataplane import ValidationError
-        from unittest.mock import patch
 
         mock_memo = Mock()
         mock_memo.config = Mock()
@@ -3485,9 +3432,6 @@ class TestOperatorErrorPaths:
 
     def test_log_haproxy_error_hints_listen_defaults_expected(self):
         """Test _log_haproxy_error_hints with 'listen' or 'defaults' expected error."""
-        from haproxy_template_ic.operator import _log_haproxy_error_hints
-        from haproxy_template_ic.dataplane import ValidationError
-        from unittest.mock import patch
 
         mock_memo = Mock()
         validation_error = ValidationError(
@@ -3513,9 +3457,6 @@ class TestOperatorErrorPaths:
 
     def test_log_haproxy_error_hints_unknown_keyword(self):
         """Test _log_haproxy_error_hints with unknown keyword error."""
-        from haproxy_template_ic.operator import _log_haproxy_error_hints
-        from haproxy_template_ic.dataplane import ValidationError
-        from unittest.mock import patch
 
         mock_memo = Mock()
         validation_error = ValidationError(
@@ -3539,9 +3480,6 @@ class TestOperatorErrorPaths:
 
     def test_log_haproxy_error_hints_missing_argument(self):
         """Test _log_haproxy_error_hints with missing argument error."""
-        from haproxy_template_ic.operator import _log_haproxy_error_hints
-        from haproxy_template_ic.dataplane import ValidationError
-        from unittest.mock import patch
 
         mock_memo = Mock()
         validation_error = ValidationError(
@@ -3565,9 +3503,6 @@ class TestOperatorErrorPaths:
 
     def test_log_haproxy_error_hints_too_many_args(self):
         """Test _log_haproxy_error_hints with too many args error."""
-        from haproxy_template_ic.operator import _log_haproxy_error_hints
-        from haproxy_template_ic.dataplane import ValidationError
-        from unittest.mock import patch
 
         mock_memo = Mock()
         validation_error = ValidationError(
@@ -3591,7 +3526,6 @@ class TestOperatorErrorPaths:
 
     def test_validation_error_registration_pattern(self):
         """Test validation error registration pattern (lines 566-578)."""
-        from unittest.mock import patch
 
         # Test the pattern used for registering validation errors
         validation_errors = []
@@ -3630,10 +3564,6 @@ class TestOperatorErrorPaths:
 
     def test_configure_webhook_server_cleanup_temp_directory(self):
         """Test configure_webhook_server cleanup of temporary directory."""
-        from unittest.mock import patch
-        import tempfile
-        import os
-        import shutil
 
         # Create a real temporary directory that exists
         real_temp_dir = tempfile.mkdtemp(prefix="test-webhook-")

--- a/tests/unit/test_structured_logging.py
+++ b/tests/unit/test_structured_logging.py
@@ -5,17 +5,22 @@ This module contains tests for structured logging functionality including
 autolog and observe decorators, JSON formatting, and context injection.
 """
 
+import asyncio
 import json
 import logging
-import asyncio
+import time
+from concurrent.futures import ThreadPoolExecutor
 from io import StringIO
 from unittest.mock import patch
 
 import structlog
+import structlog.contextvars
 from haproxy_template_ic.structured_logging import (
-    setup_structured_logging,
+    _extract_context_from_parameters,
+    _get_function_signature,
     autolog,
     observe,
+    setup_structured_logging,
 )
 
 
@@ -141,7 +146,6 @@ class TestAutologDecorator:
 
     def test_autolog_context_cleanup(self):
         """Test that autolog properly cleans up context variables."""
-        import structlog.contextvars
 
         # Clear any existing context
         structlog.contextvars.clear_contextvars()
@@ -192,7 +196,6 @@ class TestSetupLogging:
         setup_structured_logging(verbose_level=1, use_json=False)
 
         # Verify structlog is configured
-        import structlog
 
         logger = structlog.get_logger("test")
         assert logger is not None
@@ -202,7 +205,6 @@ class TestSetupLogging:
         setup_structured_logging(verbose_level=2, use_json=True)
 
         # Verify structlog is configured
-        import structlog
 
         logger = structlog.get_logger("test")
         assert logger is not None
@@ -229,9 +231,6 @@ class TestErrorHandling:
 
     def test_signature_mismatch_handling(self):
         """Test that signature mismatch in parameter extraction is handled gracefully."""
-        from haproxy_template_ic.structured_logging import (
-            _extract_context_from_parameters,
-        )
 
         def function_with_required_params(required_param: str):
             return f"called with {required_param}"
@@ -276,7 +275,6 @@ class TestErrorHandling:
 
     def test_context_cleanup_on_exception(self):
         """Test that context is cleaned up even when exceptions occur."""
-        import structlog.contextvars
 
         # Clear any existing context
         structlog.contextvars.clear_contextvars()
@@ -317,8 +315,6 @@ class TestErrorHandling:
                 assert result["component"] == "test"
                 assert "operation_id" in result
 
-            import asyncio
-
             asyncio.run(run_test())
 
     def test_parameter_extraction_with_invalid_signatures(self):
@@ -351,14 +347,11 @@ class TestEdgeCases:
 
     def test_autolog_context_isolation(self):
         """Test that autolog contexts are properly isolated between function calls."""
-        import structlog.contextvars
-        from concurrent.futures import ThreadPoolExecutor
 
         @autolog(component="worker")
         def worker_function(worker_id: str) -> dict:
             """Worker function that sets and reads context in a thread."""
             # Simulate some work
-            import time
 
             time.sleep(0.01)
 
@@ -387,7 +380,6 @@ class TestEdgeCases:
 
     def test_signature_caching_performance(self):
         """Test that function signature caching improves performance."""
-        from haproxy_template_ic.structured_logging import _get_function_signature
 
         def test_function(param1, param2="default"):
             pass


### PR DESCRIPTION
This PR refactors the codebase to follow Python best practices by moving all local imports (imports inside functions and methods) to the module level.

## Changes

- Moved unnecessary local imports to module level in 6 project files and 16 test files
- Preserved special cases where local imports are intentional:
  - Imports inside TYPE_CHECKING blocks (for type hints to avoid circular dependencies)
  - Imports inside try-except blocks (for optional dependencies like tracing)
- Improved code organization and import clarity
- Fixed indentation issues that were left from previous import statements

## Benefits

- Better code readability with all dependencies visible at the top of files
- Improved performance by loading modules once at import time rather than repeatedly in functions
- Follows Python best practices and project guidelines from CLAUDE.md
- Makes the codebase more maintainable

## Testing

All 718 unit tests pass successfully with no import errors or circular dependency issues.