### PR TITLE
fix: update GitHub workflow bot configuration

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,8 +24,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          trusted_bots: |
-            dependabot[bot]
+          allowed_bots: dependabot[bot]
           direct_prompt: |
             Review this pull request concisely. Focus on necessary improvements and actionable feedback. Keep the review under typical monitor height.
             

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,7 @@ jobs:
           additional_permissions: |
             actions: read
 
-          trusted_bots: |
-            dependabot[bot]
+          allowed_bots: dependabot[bot]
           
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
           # model: "claude-opus-4-1-20250805"


### PR DESCRIPTION
Updates GitHub Actions workflow files to use the correct parameter name for bot configuration.

## Changes
- Replace deprecated `trusted_bots` parameter with `allowed_bots` in both workflow files
- Affects claude-code-review.yml and claude.yml

## Reason
The Claude Code GitHub Action has updated its API to use `allowed_bots` instead of `trusted_bots` for specifying which bots are allowed to trigger the action.