### PR TITLE
feat: implement dedicated readiness probe for production HAProxy instances

### DIFF
--- a/charts/haproxy-template-ic/templates/_helpers.tpl
+++ b/charts/haproxy-template-ic/templates/_helpers.tpl
@@ -127,7 +127,7 @@ defaults
     timeout client 1s
     timeout server 1s
 
-frontend health
+frontend status
     bind *:{{ .healthPort }}
     http-request return status 200 content-type text/plain string "OK" if { path /healthz }
 {{- end }}

--- a/charts/haproxy-template-ic/templates/deployment-haproxy.yaml
+++ b/charts/haproxy-template-ic/templates/deployment-haproxy.yaml
@@ -73,7 +73,7 @@ spec:
             periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /ready
               port: {{ .Values.haproxy.ports.health }}
             initialDelaySeconds: 5
             periodSeconds: 5

--- a/deploy/base/configmap-universal.yaml
+++ b/deploy/base/configmap-universal.yaml
@@ -46,7 +46,7 @@ data:
         timeout client 1s
         timeout server 1s
 
-    frontend health
+    frontend status
         bind *:8404
         http-request return status 200 content-type text/plain string "OK" if { path /healthz }
         

--- a/deploy/base/configmap.yaml
+++ b/deploy/base/configmap.yaml
@@ -267,9 +267,10 @@ data:
             errorfile 503 {{ "503.http" | get_path("file") }}
             errorfile 504 {{ "504.http" | get_path("file") }}
 
-        frontend health
+        frontend status
             bind *:8404
             http-request return status 200 content-type text/plain string "OK" if { path /healthz }
+            http-request return status 200 content-type text/plain string "READY" if { path /ready }
 
         frontend http_frontend
             bind *:80

--- a/deploy/base/deployment-haproxy.yaml
+++ b/deploy/base/deployment-haproxy.yaml
@@ -52,7 +52,7 @@ spec:
             periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /ready
               port: 8404
             initialDelaySeconds: 5
             periodSeconds: 5

--- a/example-configmap.yaml
+++ b/example-configmap.yaml
@@ -212,7 +212,7 @@ data:
             bind *:80
             redirect scheme https code 301 if !{ ssl_fc }
 
-        frontend health
+        frontend status
             bind *:8404
             http-request return status 200 content-type text/plain string "OK" if { path /healthz }
 

--- a/examples/config-schema-example.yaml
+++ b/examples/config-schema-example.yaml
@@ -20,7 +20,7 @@ haproxy_config:
         timeout client 50000ms
         timeout server 50000ms
         
-    frontend health
+    frontend status
         bind *:8404
         http-request return status 200 content-type text/plain string "OK" if { path /healthz }
         

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -575,7 +575,7 @@ frontend main
     bind *:80
     default_backend servers
 
-frontend health
+frontend status
     bind *:8404
     http-request return status 200 content-type text/plain string "OK" if { path /healthz }
 
@@ -755,7 +755,7 @@ frontend main
     bind *:80
     default_backend servers
 
-frontend health
+frontend status
     bind *:8404
     http-request return status 200 content-type text/plain string "OK" if { path /healthz }
 
@@ -824,7 +824,7 @@ defaults
     timeout client 1s
     timeout server 1s
 
-frontend health
+frontend status
     bind *:8404
     http-request return status 200 content-type text/plain string "OK" if { path /healthz }
         
@@ -1843,7 +1843,7 @@ frontend main
     bind *:80
     default_backend servers
     
-frontend health
+frontend status
     bind *:8404
     http-request return status 200 content-type text/plain string "OK" if { path /healthz }
     

--- a/tests/integration/fixtures/dataplane/haproxy-valid.cfg
+++ b/tests/integration/fixtures/dataplane/haproxy-valid.cfg
@@ -11,7 +11,7 @@ frontend main
     bind *:80
     default_backend servers
 
-frontend health
+frontend status
     bind *:8404
     http-request return status 200 content-type text/plain string "OK" if { path /healthz }
 

--- a/tests/integration/fixtures/dataplane/haproxy-with-health.cfg
+++ b/tests/integration/fixtures/dataplane/haproxy-with-health.cfg
@@ -12,7 +12,7 @@ frontend main
     use_backend web_servers if { hdr(host) -i example.com }
     default_backend default_servers
 
-frontend health
+frontend status
     bind *:8404
     http-request return status 200 content-type text/plain string "OK" if { path /healthz }
     http-request return status 200 content-type application/json string "{\"status\":\"healthy\"}" if { path /health }

--- a/tests/integration/fixtures/dataplane/haproxy/haproxy-default.cfg
+++ b/tests/integration/fixtures/dataplane/haproxy/haproxy-default.cfg
@@ -10,6 +10,6 @@ defaults
     timeout client 1s
     timeout server 1s
 
-frontend health
+frontend status
     bind *:8404
     http-request return status 200 content-type text/plain string "OK" if { path /healthz }


### PR DESCRIPTION
This PR ensures production HAProxy pods only receive traffic after successful configuration deployment, addressing the issue where pods would immediately receive traffic on startup before having a valid configuration.

## Changes

- **Add /ready endpoint**: Added a new `/ready` endpoint to the HAProxy configuration template that returns "READY" when accessed
- **Update readiness probes**: Changed production HAProxy readiness probe path from `/healthz` to `/ready` in both Kubernetes manifests and Helm charts
- **Rename frontend**: Renamed the frontend from "health" to "status" across all configurations to better reflect its dual purpose of serving both health and readiness endpoints

## Technical Details

The `/ready` endpoint is only present in configurations pushed by the controller, ensuring that:
1. Production HAProxy pods start with only the `/healthz` endpoint (always available)
2. Pods remain unready until the controller pushes a configuration containing the `/ready` endpoint  
3. Only after successful configuration deployment do pods become ready to receive traffic

Validation HAProxy containers remain unchanged as they don't need readiness probes and don't serve production traffic.

## Files Modified

- `deploy/base/configmap.yaml` - Added `/ready` endpoint to HAProxy template
- `deploy/base/deployment-haproxy.yaml` - Updated readiness probe path
- `charts/haproxy-template-ic/templates/deployment-haproxy.yaml` - Updated readiness probe path
- Multiple test fixtures and example configs - Updated frontend name from "health" to "status"