### PR TITLE
feat: comprehensive template error reporting improvements with deep nesting support

### DIFF
--- a/.claude/commands/dev-env-check.md
+++ b/.claude/commands/dev-env-check.md
@@ -2,5 +2,5 @@ Start the development environment via "start-dev-env.sh" and check the following
 
 1. Did the cluster start up?
 2. Did all required pods start?
-3. Do all pods logs loog nominal or are there any warnings, errors or other unexpected log entries?
+3. Do all pods logs look nominal or are there any warnings, errors or other unexpected log entries? Grep the log for "error" and "warning".
 4. Does the internal state fetched via management CLI of the ingress controller look as expected?

--- a/charts/haproxy-template-ic/values.yaml
+++ b/charts/haproxy-template-ic/values.yaml
@@ -196,7 +196,7 @@ webhook:
           {# Generate backend server entries from EndpointSlice using indexed lookup #}
           {# This demonstrates O(1) lookup using custom indexing by service name #}
           {% for endpoint_slice in resources.get('endpoints', {}).get_indexed(service_name) %}
-            {% for endpoint in endpoint_slice.endpoints %}
+            {% for endpoint in endpoint_slice.get('endpoints', []) %}
               {% for address in endpoint.addresses %}
           server {{ endpoint.targetRef.name }} {{ address }}:{{ port }}
               {% endfor %}

--- a/charts/haproxy-template-ic/values.yaml
+++ b/charts/haproxy-template-ic/values.yaml
@@ -196,7 +196,7 @@ webhook:
           {# Generate backend server entries from EndpointSlice using indexed lookup #}
           {# This demonstrates O(1) lookup using custom indexing by service name #}
           {% for endpoint_slice in resources.get('endpoints', {}).get_indexed(service_name) %}
-            {% for endpoint in endpoint_slice.get('endpoints', []) %}
+            {% for endpoint in endpoint_slice.get('endpoints') | default([], true) %}
               {% for address in endpoint.addresses %}
           server {{ endpoint.targetRef.name }} {{ address }}:{{ port }}
               {% endfor %}

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/create_acl_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/create_acl_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACLLines, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[ACLLines, Error]:
     if response.status_code == 201:
         response_201 = ACLLines.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = ACLLines.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/create_acl_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/create_acl_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACLLines, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[ACLLines, Error]:
     if response.status_code == 201:
         response_201 = ACLLines.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = ACLLines.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/create_acl_fcgi_app.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/create_acl_fcgi_app.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACLLines, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[ACLLines, Error]:
     if response.status_code == 201:
         response_201 = ACLLines.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = ACLLines.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/create_acl_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/create_acl_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACLLines, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[ACLLines, Error]:
     if response.status_code == 201:
         response_201 = ACLLines.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = ACLLines.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/delete_acl_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/delete_acl_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/delete_acl_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/delete_acl_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/delete_acl_fcgi_app.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/delete_acl_fcgi_app.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/delete_acl_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/delete_acl_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_acl_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_acl_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACLLines, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[ACLLines, Error]:
     if response.status_code == 200:
         response_200 = ACLLines.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_acl_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_acl_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACLLines, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[ACLLines, Error]:
     if response.status_code == 200:
         response_200 = ACLLines.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_acl_fcgi_app.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_acl_fcgi_app.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACLLines, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[ACLLines, Error]:
     if response.status_code == 200:
         response_200 = ACLLines.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_acl_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_acl_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACLLines, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[ACLLines, Error]:
     if response.status_code == 200:
         response_200 = ACLLines.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_all_acl_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_all_acl_backend.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -34,7 +34,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["ACLLines"]]:
+) -> Union[Error, list["ACLLines"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -44,15 +44,15 @@ def _parse_response(
             response_200.append(componentsschemasacls_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["ACLLines"]]:
+) -> Response[Union[Error, list["ACLLines"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -67,7 +67,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ACLLines"]]:
+) -> Response[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -82,7 +82,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ACLLines']]
+        Response[Union[Error, list['ACLLines']]]
     """
 
     kwargs = _get_kwargs(
@@ -104,7 +104,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ACLLines"]]:
+) -> Optional[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -119,7 +119,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ACLLines']
+        Union[Error, list['ACLLines']]
     """
 
     return sync_detailed(
@@ -136,7 +136,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ACLLines"]]:
+) -> Response[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -151,7 +151,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ACLLines']]
+        Response[Union[Error, list['ACLLines']]]
     """
 
     kwargs = _get_kwargs(
@@ -171,7 +171,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ACLLines"]]:
+) -> Optional[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -186,7 +186,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ACLLines']
+        Union[Error, list['ACLLines']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_all_acl_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_all_acl_defaults.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -34,7 +34,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["ACLLines"]]:
+) -> Union[Error, list["ACLLines"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -44,15 +44,15 @@ def _parse_response(
             response_200.append(componentsschemasacls_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["ACLLines"]]:
+) -> Response[Union[Error, list["ACLLines"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -67,7 +67,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ACLLines"]]:
+) -> Response[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -82,7 +82,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ACLLines']]
+        Response[Union[Error, list['ACLLines']]]
     """
 
     kwargs = _get_kwargs(
@@ -104,7 +104,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ACLLines"]]:
+) -> Optional[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -119,7 +119,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ACLLines']
+        Union[Error, list['ACLLines']]
     """
 
     return sync_detailed(
@@ -136,7 +136,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ACLLines"]]:
+) -> Response[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -151,7 +151,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ACLLines']]
+        Response[Union[Error, list['ACLLines']]]
     """
 
     kwargs = _get_kwargs(
@@ -171,7 +171,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ACLLines"]]:
+) -> Optional[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -186,7 +186,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ACLLines']
+        Union[Error, list['ACLLines']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_all_acl_fcgi_app.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_all_acl_fcgi_app.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -34,7 +34,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["ACLLines"]]:
+) -> Union[Error, list["ACLLines"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -44,15 +44,15 @@ def _parse_response(
             response_200.append(componentsschemasacls_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["ACLLines"]]:
+) -> Response[Union[Error, list["ACLLines"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -67,7 +67,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ACLLines"]]:
+) -> Response[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -82,7 +82,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ACLLines']]
+        Response[Union[Error, list['ACLLines']]]
     """
 
     kwargs = _get_kwargs(
@@ -104,7 +104,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ACLLines"]]:
+) -> Optional[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -119,7 +119,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ACLLines']
+        Union[Error, list['ACLLines']]
     """
 
     return sync_detailed(
@@ -136,7 +136,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ACLLines"]]:
+) -> Response[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -151,7 +151,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ACLLines']]
+        Response[Union[Error, list['ACLLines']]]
     """
 
     kwargs = _get_kwargs(
@@ -171,7 +171,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ACLLines"]]:
+) -> Optional[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -186,7 +186,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ACLLines']
+        Union[Error, list['ACLLines']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_all_acl_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/get_all_acl_frontend.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -34,7 +34,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["ACLLines"]]:
+) -> Union[Error, list["ACLLines"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -44,15 +44,15 @@ def _parse_response(
             response_200.append(componentsschemasacls_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["ACLLines"]]:
+) -> Response[Union[Error, list["ACLLines"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -67,7 +67,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ACLLines"]]:
+) -> Response[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -82,7 +82,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ACLLines']]
+        Response[Union[Error, list['ACLLines']]]
     """
 
     kwargs = _get_kwargs(
@@ -104,7 +104,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ACLLines"]]:
+) -> Optional[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -119,7 +119,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ACLLines']
+        Union[Error, list['ACLLines']]
     """
 
     return sync_detailed(
@@ -136,7 +136,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ACLLines"]]:
+) -> Response[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -151,7 +151,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ACLLines']]
+        Response[Union[Error, list['ACLLines']]]
     """
 
     kwargs = _get_kwargs(
@@ -171,7 +171,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     acl_name: Union[Unset, str] = UNSET,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ACLLines"]]:
+) -> Optional[Union[Error, list["ACLLines"]]]:
     """Return an array of all ACL lines
 
      Returns all ACL lines that are configured in specified parent.
@@ -186,7 +186,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ACLLines']
+        Union[Error, list['ACLLines']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_acl_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_acl_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACLLines, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[ACLLines, Error]:
     if response.status_code == 200:
         response_200 = ACLLines.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = ACLLines.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_acl_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_acl_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACLLines, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[ACLLines, Error]:
     if response.status_code == 200:
         response_200 = ACLLines.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = ACLLines.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_acl_fcgi_app.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_acl_fcgi_app.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACLLines, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[ACLLines, Error]:
     if response.status_code == 200:
         response_200 = ACLLines.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = ACLLines.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_acl_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_acl_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACLLines, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[ACLLines, Error]:
     if response.status_code == 200:
         response_200 = ACLLines.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = ACLLines.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_all_acl_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_all_acl_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemasacls_item_data in body:
         componentsschemasacls_item = componentsschemasacls_item_data.to_dict()
-        _body.append(componentsschemasacls_item)
+        _kwargs["json"].append(componentsschemasacls_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["ACLLines"]]]:
+) -> Union[Error, list["ACLLines"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemasacls_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemasacls_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_all_acl_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_all_acl_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemasacls_item_data in body:
         componentsschemasacls_item = componentsschemasacls_item_data.to_dict()
-        _body.append(componentsschemasacls_item)
+        _kwargs["json"].append(componentsschemasacls_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["ACLLines"]]]:
+) -> Union[Error, list["ACLLines"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemasacls_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemasacls_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_all_acl_fcgi_app.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_all_acl_fcgi_app.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemasacls_item_data in body:
         componentsschemasacls_item = componentsschemasacls_item_data.to_dict()
-        _body.append(componentsschemasacls_item)
+        _kwargs["json"].append(componentsschemasacls_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["ACLLines"]]]:
+) -> Union[Error, list["ACLLines"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemasacls_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemasacls_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_all_acl_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl/replace_all_acl_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_lines import ACLLines
 from ...models.error import Error
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemasacls_item_data in body:
         componentsschemasacls_item = componentsschemasacls_item_data.to_dict()
-        _body.append(componentsschemasacls_item)
+        _kwargs["json"].append(componentsschemasacls_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["ACLLines"]]]:
+) -> Union[Error, list["ACLLines"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemasacls_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemasacls_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/add_payload_runtime_acl.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/add_payload_runtime_acl.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.one_acl_file_entry import OneACLFileEntry
@@ -22,12 +21,11 @@ def _get_kwargs(
         "url": f"/services/haproxy/runtime/acls/{parent_name}/entries",
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemasacl_files_entries_item_data in body:
         componentsschemasacl_files_entries_item = componentsschemasacl_files_entries_item_data.to_dict()
-        _body.append(componentsschemasacl_files_entries_item)
+        _kwargs["json"].append(componentsschemasacl_files_entries_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -36,7 +34,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["OneACLFileEntry"]]]:
+) -> Union[Error, list["OneACLFileEntry"]]:
     if response.status_code == 201:
         response_201 = []
         _response_201 = response.json()
@@ -48,14 +46,15 @@ def _parse_response(
             response_201.append(componentsschemasacl_files_entries_item)
 
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/delete_services_haproxy_runtime_acls_parent_name_entries_id.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/delete_services_haproxy_runtime_acls_parent_name_entries_id.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import Response
@@ -21,24 +20,24 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/get_services_haproxy_runtime_acls.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/get_services_haproxy_runtime_acls.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_file import ACLFile
+from ...models.error import Error
 from ...types import Response
 
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["ACLFile"]]:
+) -> Union[Error, list["ACLFile"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasacl_files_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["ACLFile"]]:
+) -> Response[Union[Error, list["ACLFile"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["ACLFile"]]:
+) -> Response[Union[Error, list["ACLFile"]]]:
     """Return an array of all ACL files
 
      Returns all ACL files using the runtime socket.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ACLFile']]
+        Response[Union[Error, list['ACLFile']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["ACLFile"]]:
+) -> Optional[Union[Error, list["ACLFile"]]]:
     """Return an array of all ACL files
 
      Returns all ACL files using the runtime socket.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ACLFile']
+        Union[Error, list['ACLFile']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["ACLFile"]]:
+) -> Response[Union[Error, list["ACLFile"]]]:
     """Return an array of all ACL files
 
      Returns all ACL files using the runtime socket.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ACLFile']]
+        Response[Union[Error, list['ACLFile']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["ACLFile"]]:
+) -> Optional[Union[Error, list["ACLFile"]]]:
     """Return an array of all ACL files
 
      Returns all ACL files using the runtime socket.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ACLFile']
+        Union[Error, list['ACLFile']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/get_services_haproxy_runtime_acls_id.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/get_services_haproxy_runtime_acls_id.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acl_file import ACLFile
 from ...models.error import Error
@@ -21,21 +20,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACLFile, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[ACLFile, Error]:
     if response.status_code == 200:
         response_200 = ACLFile.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/get_services_haproxy_runtime_acls_parent_name_entries.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/get_services_haproxy_runtime_acls_parent_name_entries.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.one_acl_file_entry import OneACLFileEntry
@@ -23,7 +22,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["OneACLFileEntry"]]]:
+) -> Union[Error, list["OneACLFileEntry"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -35,18 +34,20 @@ def _parse_response(
             response_200.append(componentsschemasacl_files_entries_item)
 
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/get_services_haproxy_runtime_acls_parent_name_entries_id.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/get_services_haproxy_runtime_acls_parent_name_entries_id.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.one_acl_file_entry import OneACLFileEntry
@@ -24,23 +23,25 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, OneACLFileEntry]]:
+) -> Union[Error, OneACLFileEntry]:
     if response.status_code == 200:
         response_200 = OneACLFileEntry.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/post_services_haproxy_runtime_acls_parent_name_entries.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acl_runtime/post_services_haproxy_runtime_acls_parent_name_entries.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.one_acl_file_entry import OneACLFileEntry
@@ -22,9 +21,8 @@ def _get_kwargs(
         "url": f"/services/haproxy/runtime/acls/{parent_name}/entries",
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -33,23 +31,25 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, OneACLFileEntry]]:
+) -> Union[Error, OneACLFileEntry]:
     if response.status_code == 201:
         response_201 = OneACLFileEntry.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acme/create_acme_provider.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acme/create_acme_provider.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acme_provider import ACMEProvider
 from ...models.error import Error
@@ -35,9 +34,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -46,27 +44,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACMEProvider, Error]]:
+) -> Union[ACMEProvider, Error]:
     if response.status_code == 201:
         response_201 = ACMEProvider.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = ACMEProvider.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acme/delete_acme_provider.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acme/delete_acme_provider.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acme/edit_acme_provider.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acme/edit_acme_provider.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acme_provider import ACMEProvider
 from ...models.error import Error
@@ -36,9 +35,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -47,27 +45,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACMEProvider, Error]]:
+) -> Union[ACMEProvider, Error]:
     if response.status_code == 200:
         response_200 = ACMEProvider.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = ACMEProvider.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acme/get_acme_provider.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acme/get_acme_provider.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acme_provider import ACMEProvider
 from ...models.error import Error
@@ -32,19 +31,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ACMEProvider, Error]]:
+) -> Union[ACMEProvider, Error]:
     if response.status_code == 200:
         response_200 = ACMEProvider.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acme/get_acme_providers.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/acme/get_acme_providers.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.acme_provider import ACMEProvider
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -30,7 +30,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["ACMEProvider"]]:
+) -> Union[Error, list["ACMEProvider"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -40,15 +40,15 @@ def _parse_response(
             response_200.append(componentsschemasacme_providers_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["ACMEProvider"]]:
+) -> Response[Union[Error, list["ACMEProvider"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -61,7 +61,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ACMEProvider"]]:
+) -> Response[Union[Error, list["ACMEProvider"]]]:
     """Return all the ACME providers
 
      Returns an array of all the configured ACME providers
@@ -74,7 +74,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ACMEProvider']]
+        Response[Union[Error, list['ACMEProvider']]]
     """
 
     kwargs = _get_kwargs(
@@ -92,7 +92,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ACMEProvider"]]:
+) -> Optional[Union[Error, list["ACMEProvider"]]]:
     """Return all the ACME providers
 
      Returns an array of all the configured ACME providers
@@ -105,7 +105,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ACMEProvider']
+        Union[Error, list['ACMEProvider']]
     """
 
     return sync_detailed(
@@ -118,7 +118,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ACMEProvider"]]:
+) -> Response[Union[Error, list["ACMEProvider"]]]:
     """Return all the ACME providers
 
      Returns an array of all the configured ACME providers
@@ -131,7 +131,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ACMEProvider']]
+        Response[Union[Error, list['ACMEProvider']]]
     """
 
     kwargs = _get_kwargs(
@@ -147,7 +147,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ACMEProvider"]]:
+) -> Optional[Union[Error, list["ACMEProvider"]]]:
     """Return all the ACME providers
 
      Returns an array of all the configured ACME providers
@@ -160,7 +160,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ACMEProvider']
+        Union[Error, list['ACMEProvider']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend/create_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend/create_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.backend import Backend
 from ...models.error import Error
@@ -38,38 +37,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Backend, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Backend, Error]:
     if response.status_code == 201:
         response_201 = Backend.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Backend.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend/delete_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend/delete_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend/get_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend/get_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.backend import Backend
 from ...models.error import Error
@@ -33,21 +32,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Backend, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Backend, Error]:
     if response.status_code == 200:
         response_200 = Backend.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend/get_backends.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend/get_backends.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.backend import Backend
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -33,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Backend"]]:
+) -> Union[Error, list["Backend"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasbackends_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Backend"]]:
+) -> Response[Union[Error, list["Backend"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["Backend"]]:
+) -> Response[Union[Error, list["Backend"]]]:
     """Return an array of backends
 
      Returns an array of all configured backends.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Backend']]
+        Response[Union[Error, list['Backend']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["Backend"]]:
+) -> Optional[Union[Error, list["Backend"]]]:
     """Return an array of backends
 
      Returns an array of all configured backends.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Backend']
+        Union[Error, list['Backend']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["Backend"]]:
+) -> Response[Union[Error, list["Backend"]]]:
     """Return an array of backends
 
      Returns an array of all configured backends.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Backend']]
+        Response[Union[Error, list['Backend']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["Backend"]]:
+) -> Optional[Union[Error, list["Backend"]]]:
     """Return an array of backends
 
      Returns an array of all configured backends.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Backend']
+        Union[Error, list['Backend']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend/replace_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend/replace_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.backend import Backend
 from ...models.error import Error
@@ -39,38 +38,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Backend, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Backend, Error]:
     if response.status_code == 200:
         response_200 = Backend.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Backend.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend_switching_rule/create_backend_switching_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend_switching_rule/create_backend_switching_rule.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.backend_switching_rule import BackendSwitchingRule
 from ...models.error import Error
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[BackendSwitchingRule, Error]]:
+) -> Union[BackendSwitchingRule, Error]:
     if response.status_code == 201:
         response_201 = BackendSwitchingRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = BackendSwitchingRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend_switching_rule/delete_backend_switching_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend_switching_rule/delete_backend_switching_rule.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend_switching_rule/get_backend_switching_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend_switching_rule/get_backend_switching_rule.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.backend_switching_rule import BackendSwitchingRule
 from ...models.error import Error
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[BackendSwitchingRule, Error]]:
+) -> Union[BackendSwitchingRule, Error]:
     if response.status_code == 200:
         response_200 = BackendSwitchingRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend_switching_rule/get_backend_switching_rules.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend_switching_rule/get_backend_switching_rules.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.backend_switching_rule import BackendSwitchingRule
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["BackendSwitchingRule"]]:
+) -> Union[Error, list["BackendSwitchingRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasbackend_switching_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["BackendSwitchingRule"]]:
+) -> Response[Union[Error, list["BackendSwitchingRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["BackendSwitchingRule"]]:
+) -> Response[Union[Error, list["BackendSwitchingRule"]]]:
     """Return an array of all Backend Switching Rules
 
      Returns all Backend Switching Rules that are configured in specified frontend.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['BackendSwitchingRule']]
+        Response[Union[Error, list['BackendSwitchingRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["BackendSwitchingRule"]]:
+) -> Optional[Union[Error, list["BackendSwitchingRule"]]]:
     """Return an array of all Backend Switching Rules
 
      Returns all Backend Switching Rules that are configured in specified frontend.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['BackendSwitchingRule']
+        Union[Error, list['BackendSwitchingRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["BackendSwitchingRule"]]:
+) -> Response[Union[Error, list["BackendSwitchingRule"]]]:
     """Return an array of all Backend Switching Rules
 
      Returns all Backend Switching Rules that are configured in specified frontend.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['BackendSwitchingRule']]
+        Response[Union[Error, list['BackendSwitchingRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["BackendSwitchingRule"]]:
+) -> Optional[Union[Error, list["BackendSwitchingRule"]]]:
     """Return an array of all Backend Switching Rules
 
      Returns all Backend Switching Rules that are configured in specified frontend.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['BackendSwitchingRule']
+        Union[Error, list['BackendSwitchingRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend_switching_rule/replace_backend_switching_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend_switching_rule/replace_backend_switching_rule.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.backend_switching_rule import BackendSwitchingRule
 from ...models.error import Error
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[BackendSwitchingRule, Error]]:
+) -> Union[BackendSwitchingRule, Error]:
     if response.status_code == 200:
         response_200 = BackendSwitchingRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = BackendSwitchingRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend_switching_rule/replace_backend_switching_rules.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/backend_switching_rule/replace_backend_switching_rules.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.backend_switching_rule import BackendSwitchingRule
 from ...models.error import Error
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemasbackend_switching_rules_item_data in body:
         componentsschemasbackend_switching_rules_item = componentsschemasbackend_switching_rules_item_data.to_dict()
-        _body.append(componentsschemasbackend_switching_rules_item)
+        _kwargs["json"].append(componentsschemasbackend_switching_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["BackendSwitchingRule"]]]:
+) -> Union[Error, list["BackendSwitchingRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemasbackend_switching_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemasbackend_switching_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/create_bind_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/create_bind_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bind import Bind
 from ...models.error import Error
@@ -36,38 +35,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Bind, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Bind, Error]:
     if response.status_code == 201:
         response_201 = Bind.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Bind.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/create_bind_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/create_bind_log_forward.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bind import Bind
 from ...models.error import Error
@@ -36,38 +35,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Bind, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Bind, Error]:
     if response.status_code == 201:
         response_201 = Bind.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Bind.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/create_bind_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/create_bind_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bind import Bind
 from ...models.error import Error
@@ -36,38 +35,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Bind, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Bind, Error]:
     if response.status_code == 201:
         response_201 = Bind.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Bind.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/delete_bind_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/delete_bind_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/delete_bind_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/delete_bind_log_forward.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/delete_bind_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/delete_bind_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/get_all_bind_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/get_all_bind_frontend.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bind import Bind
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -29,7 +29,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[list["Bind"]]:
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Union[Error, list["Bind"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -39,13 +41,15 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
             response_200.append(componentsschemasbinds_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[list["Bind"]]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, list["Bind"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -59,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Bind"]]:
+) -> Response[Union[Error, list["Bind"]]]:
     """Return an array of binds
 
      Returns an array of all binds that are configured in specified frontend.
@@ -73,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Bind']]
+        Response[Union[Error, list['Bind']]]
     """
 
     kwargs = _get_kwargs(
@@ -93,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Bind"]]:
+) -> Optional[Union[Error, list["Bind"]]]:
     """Return an array of binds
 
      Returns an array of all binds that are configured in specified frontend.
@@ -107,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Bind']
+        Union[Error, list['Bind']]
     """
 
     return sync_detailed(
@@ -122,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Bind"]]:
+) -> Response[Union[Error, list["Bind"]]]:
     """Return an array of binds
 
      Returns an array of all binds that are configured in specified frontend.
@@ -136,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Bind']]
+        Response[Union[Error, list['Bind']]]
     """
 
     kwargs = _get_kwargs(
@@ -154,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Bind"]]:
+) -> Optional[Union[Error, list["Bind"]]]:
     """Return an array of binds
 
      Returns an array of all binds that are configured in specified frontend.
@@ -168,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Bind']
+        Union[Error, list['Bind']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/get_all_bind_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/get_all_bind_log_forward.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bind import Bind
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -29,7 +29,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[list["Bind"]]:
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Union[Error, list["Bind"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -39,13 +41,15 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
             response_200.append(componentsschemasbinds_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[list["Bind"]]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, list["Bind"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -59,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Bind"]]:
+) -> Response[Union[Error, list["Bind"]]]:
     """Return an array of binds
 
      Returns an array of all binds that are configured in specified frontend.
@@ -73,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Bind']]
+        Response[Union[Error, list['Bind']]]
     """
 
     kwargs = _get_kwargs(
@@ -93,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Bind"]]:
+) -> Optional[Union[Error, list["Bind"]]]:
     """Return an array of binds
 
      Returns an array of all binds that are configured in specified frontend.
@@ -107,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Bind']
+        Union[Error, list['Bind']]
     """
 
     return sync_detailed(
@@ -122,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Bind"]]:
+) -> Response[Union[Error, list["Bind"]]]:
     """Return an array of binds
 
      Returns an array of all binds that are configured in specified frontend.
@@ -136,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Bind']]
+        Response[Union[Error, list['Bind']]]
     """
 
     kwargs = _get_kwargs(
@@ -154,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Bind"]]:
+) -> Optional[Union[Error, list["Bind"]]]:
     """Return an array of binds
 
      Returns an array of all binds that are configured in specified frontend.
@@ -168,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Bind']
+        Union[Error, list['Bind']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/get_all_bind_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/get_all_bind_peer.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bind import Bind
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -29,7 +29,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[list["Bind"]]:
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Union[Error, list["Bind"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -39,13 +41,15 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
             response_200.append(componentsschemasbinds_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[list["Bind"]]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, list["Bind"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -59,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Bind"]]:
+) -> Response[Union[Error, list["Bind"]]]:
     """Return an array of binds
 
      Returns an array of all binds that are configured in specified frontend.
@@ -73,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Bind']]
+        Response[Union[Error, list['Bind']]]
     """
 
     kwargs = _get_kwargs(
@@ -93,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Bind"]]:
+) -> Optional[Union[Error, list["Bind"]]]:
     """Return an array of binds
 
      Returns an array of all binds that are configured in specified frontend.
@@ -107,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Bind']
+        Union[Error, list['Bind']]
     """
 
     return sync_detailed(
@@ -122,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Bind"]]:
+) -> Response[Union[Error, list["Bind"]]]:
     """Return an array of binds
 
      Returns an array of all binds that are configured in specified frontend.
@@ -136,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Bind']]
+        Response[Union[Error, list['Bind']]]
     """
 
     kwargs = _get_kwargs(
@@ -154,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Bind"]]:
+) -> Optional[Union[Error, list["Bind"]]]:
     """Return an array of binds
 
      Returns an array of all binds that are configured in specified frontend.
@@ -168,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Bind']
+        Union[Error, list['Bind']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/get_bind_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/get_bind_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bind import Bind
 from ...models.error import Error
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Bind, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Bind, Error]:
     if response.status_code == 200:
         response_200 = Bind.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/get_bind_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/get_bind_log_forward.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bind import Bind
 from ...models.error import Error
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Bind, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Bind, Error]:
     if response.status_code == 200:
         response_200 = Bind.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/get_bind_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/get_bind_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bind import Bind
 from ...models.error import Error
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Bind, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Bind, Error]:
     if response.status_code == 200:
         response_200 = Bind.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/replace_bind_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/replace_bind_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bind import Bind
 from ...models.error import Error
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Bind, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Bind, Error]:
     if response.status_code == 200:
         response_200 = Bind.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Bind.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/replace_bind_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/replace_bind_log_forward.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bind import Bind
 from ...models.error import Error
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Bind, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Bind, Error]:
     if response.status_code == 200:
         response_200 = Bind.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Bind.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/replace_bind_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/bind/replace_bind_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bind import Bind
 from ...models.error import Error
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Bind, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Bind, Error]:
     if response.status_code == 200:
         response_200 = Bind.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Bind.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cache/create_cache.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cache/create_cache.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.cache import Cache
 from ...models.error import Error
@@ -35,38 +34,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Cache, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Cache, Error]:
     if response.status_code == 201:
         response_201 = Cache.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Cache.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cache/delete_cache.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cache/delete_cache.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cache/get_cache.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cache/get_cache.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.cache import Cache
 from ...models.error import Error
@@ -30,21 +29,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Cache, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Cache, Error]:
     if response.status_code == 200:
         response_200 = Cache.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cache/get_caches.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cache/get_caches.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.cache import Cache
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -28,7 +28,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[list["Cache"]]:
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Union[Error, list["Cache"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -38,13 +40,15 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
             response_200.append(componentsschemascaches_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[list["Cache"]]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, list["Cache"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -57,7 +61,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Cache"]]:
+) -> Response[Union[Error, list["Cache"]]]:
     """Return an array of caches
 
      Returns an array of all configured caches.
@@ -70,7 +74,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Cache']]
+        Response[Union[Error, list['Cache']]]
     """
 
     kwargs = _get_kwargs(
@@ -88,7 +92,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Cache"]]:
+) -> Optional[Union[Error, list["Cache"]]]:
     """Return an array of caches
 
      Returns an array of all configured caches.
@@ -101,7 +105,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Cache']
+        Union[Error, list['Cache']]
     """
 
     return sync_detailed(
@@ -114,7 +118,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Cache"]]:
+) -> Response[Union[Error, list["Cache"]]]:
     """Return an array of caches
 
      Returns an array of all configured caches.
@@ -127,7 +131,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Cache']]
+        Response[Union[Error, list['Cache']]]
     """
 
     kwargs = _get_kwargs(
@@ -143,7 +147,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Cache"]]:
+) -> Optional[Union[Error, list["Cache"]]]:
     """Return an array of caches
 
      Returns an array of all configured caches.
@@ -156,7 +160,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Cache']
+        Union[Error, list['Cache']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cache/replace_cache.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cache/replace_cache.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.cache import Cache
 from ...models.error import Error
@@ -36,38 +35,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Cache, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Cache, Error]:
     if response.status_code == 200:
         response_200 = Cache.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Cache.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cluster/delete_cluster.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cluster/delete_cluster.py
@@ -1,11 +1,11 @@
 from http import HTTPStatus
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_cluster_configuration import DeleteClusterConfiguration
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -35,16 +35,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
-        return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+        response_204 = cast(Any, None)
+        return response_204
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Any]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, Error]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -58,7 +61,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     configuration: Union[Unset, DeleteClusterConfiguration] = UNSET,
     version: Union[Unset, int] = UNSET,
-) -> Response[Any]:
+) -> Response[Union[Any, Error]]:
     """Delete cluster settings
 
      Delete cluster settings and move the node back to single mode
@@ -72,7 +75,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[Union[Any, Error]]
     """
 
     kwargs = _get_kwargs(
@@ -87,12 +90,12 @@ def sync_detailed(
     return _build_response(client=client, response=response)
 
 
-async def asyncio_detailed(
+def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     configuration: Union[Unset, DeleteClusterConfiguration] = UNSET,
     version: Union[Unset, int] = UNSET,
-) -> Response[Any]:
+) -> Optional[Union[Any, Error]]:
     """Delete cluster settings
 
      Delete cluster settings and move the node back to single mode
@@ -106,7 +109,36 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Union[Any, Error]
+    """
+
+    return sync_detailed(
+        client=client,
+        configuration=configuration,
+        version=version,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    configuration: Union[Unset, DeleteClusterConfiguration] = UNSET,
+    version: Union[Unset, int] = UNSET,
+) -> Response[Union[Any, Error]]:
+    """Delete cluster settings
+
+     Delete cluster settings and move the node back to single mode
+
+    Args:
+        configuration (Union[Unset, DeleteClusterConfiguration]):
+        version (Union[Unset, int]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, Error]]
     """
 
     kwargs = _get_kwargs(
@@ -117,3 +149,34 @@ async def asyncio_detailed(
     response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    configuration: Union[Unset, DeleteClusterConfiguration] = UNSET,
+    version: Union[Unset, int] = UNSET,
+) -> Optional[Union[Any, Error]]:
+    """Delete cluster settings
+
+     Delete cluster settings and move the node back to single mode
+
+    Args:
+        configuration (Union[Unset, DeleteClusterConfiguration]):
+        version (Union[Unset, int]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, Error]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            configuration=configuration,
+            version=version,
+        )
+    ).parsed

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cluster/edit_cluster.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cluster/edit_cluster.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.cluster_settings import ClusterSettings
 from ...models.error import Error
@@ -29,9 +28,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -40,19 +38,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ClusterSettings, Error]]:
+) -> Union[ClusterSettings, Error]:
     if response.status_code == 200:
         response_200 = ClusterSettings.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cluster/get_cluster.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cluster/get_cluster.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.cluster_settings import ClusterSettings
+from ...models.error import Error
 from ...types import Response
 
 
@@ -20,20 +20,20 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[ClusterSettings]:
+) -> Union[ClusterSettings, Error]:
     if response.status_code == 200:
         response_200 = ClusterSettings.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[ClusterSettings]:
+) -> Response[Union[ClusterSettings, Error]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -45,7 +45,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[ClusterSettings]:
+) -> Response[Union[ClusterSettings, Error]]:
     """Return cluster data
 
      Returns cluster data
@@ -55,7 +55,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[ClusterSettings]
+        Response[Union[ClusterSettings, Error]]
     """
 
     kwargs = _get_kwargs()
@@ -70,7 +70,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[ClusterSettings]:
+) -> Optional[Union[ClusterSettings, Error]]:
     """Return cluster data
 
      Returns cluster data
@@ -80,7 +80,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        ClusterSettings
+        Union[ClusterSettings, Error]
     """
 
     return sync_detailed(
@@ -91,7 +91,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[ClusterSettings]:
+) -> Response[Union[ClusterSettings, Error]]:
     """Return cluster data
 
      Returns cluster data
@@ -101,7 +101,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[ClusterSettings]
+        Response[Union[ClusterSettings, Error]]
     """
 
     kwargs = _get_kwargs()
@@ -114,7 +114,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[ClusterSettings]:
+) -> Optional[Union[ClusterSettings, Error]]:
     """Return cluster data
 
      Returns cluster data
@@ -124,7 +124,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        ClusterSettings
+        Union[ClusterSettings, Error]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cluster/initiate_certificate_refresh.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cluster/initiate_certificate_refresh.py
@@ -1,10 +1,10 @@
 from http import HTTPStatus
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...types import Response
 
 
@@ -17,18 +17,23 @@ def _get_kwargs() -> dict[str, Any]:
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 200:
-        return None
+        response_200 = cast(Any, None)
+        return response_200
+
     if response.status_code == 403:
-        return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+        response_403 = cast(Any, None)
+        return response_403
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Any]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, Error]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -40,7 +45,7 @@ def _build_response(*, client: Union[AuthenticatedClient, Client], response: htt
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[Any]:
+) -> Response[Union[Any, Error]]:
     """Initiates a certificate refresh
 
      Initiates a certificate refresh
@@ -50,7 +55,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[Union[Any, Error]]
     """
 
     kwargs = _get_kwargs()
@@ -62,10 +67,10 @@ def sync_detailed(
     return _build_response(client=client, response=response)
 
 
-async def asyncio_detailed(
+def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[Any]:
+) -> Optional[Union[Any, Error]]:
     """Initiates a certificate refresh
 
      Initiates a certificate refresh
@@ -75,7 +80,28 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Union[Any, Error]
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[Any, Error]]:
+    """Initiates a certificate refresh
+
+     Initiates a certificate refresh
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, Error]]
     """
 
     kwargs = _get_kwargs()
@@ -83,3 +109,26 @@ async def asyncio_detailed(
     response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[Any, Error]]:
+    """Initiates a certificate refresh
+
+     Initiates a certificate refresh
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, Error]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cluster/post_cluster.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/cluster/post_cluster.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.cluster_settings import ClusterSettings
 from ...models.error import Error
@@ -43,9 +42,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -54,19 +52,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ClusterSettings, Error]]:
+) -> Union[ClusterSettings, Error]:
     if response.status_code == 200:
         response_200 = ClusterSettings.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/configuration/get_configuration_version.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/configuration/get_configuration_version.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -28,20 +27,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, int]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, int]:
     if response.status_code == 200:
         response_200 = cast(int, response.json())
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/configuration/get_ha_proxy_configuration.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/configuration/get_ha_proxy_configuration.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...types import UNSET, Response, Unset
 
@@ -30,14 +29,13 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[str]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> str:
     if response.status_code == 200:
         response_200 = response.text
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = response.text
+    return response_default
 
 
 def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[str]:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/configuration/post_ha_proxy_configuration.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/configuration/post_ha_proxy_configuration.py
@@ -1,0 +1,261 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: str,
+    skip_version: Union[Unset, bool] = False,
+    skip_reload: Union[Unset, bool] = False,
+    only_validate: Union[Unset, bool] = False,
+    version: Union[Unset, int] = UNSET,
+    force_reload: Union[Unset, bool] = False,
+    x_runtime_actions: Union[Unset, str] = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_runtime_actions, Unset):
+        headers["X-Runtime-Actions"] = x_runtime_actions
+
+    params: dict[str, Any] = {}
+
+    params["skip_version"] = skip_version
+
+    params["skip_reload"] = skip_reload
+
+    params["only_validate"] = only_validate
+
+    params["version"] = version
+
+    params["force_reload"] = force_reload
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/services/haproxy/configuration/raw",
+        "params": params,
+    }
+
+    _kwargs["content"] = body
+
+    headers["Content-Type"] = "text/plain"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> str:
+    if response.status_code == 201:
+        response_201 = response.text
+        return response_201
+
+    if response.status_code == 202:
+        response_202 = response.text
+        return response_202
+
+    if response.status_code == 400:
+        response_400 = response.text
+        return response_400
+
+    response_default = response.text
+    return response_default
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[str]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_version: Union[Unset, bool] = False,
+    skip_reload: Union[Unset, bool] = False,
+    only_validate: Union[Unset, bool] = False,
+    version: Union[Unset, int] = UNSET,
+    force_reload: Union[Unset, bool] = False,
+    x_runtime_actions: Union[Unset, str] = UNSET,
+) -> Response[str]:
+    """Push new haproxy configuration
+
+     Push a new haproxy configuration file in plain text
+
+    Args:
+        skip_version (Union[Unset, bool]):  Default: False.
+        skip_reload (Union[Unset, bool]):  Default: False.
+        only_validate (Union[Unset, bool]):  Default: False.
+        version (Union[Unset, int]):
+        force_reload (Union[Unset, bool]):  Default: False.
+        x_runtime_actions (Union[Unset, str]):
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[str]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        skip_version=skip_version,
+        skip_reload=skip_reload,
+        only_validate=only_validate,
+        version=version,
+        force_reload=force_reload,
+        x_runtime_actions=x_runtime_actions,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_version: Union[Unset, bool] = False,
+    skip_reload: Union[Unset, bool] = False,
+    only_validate: Union[Unset, bool] = False,
+    version: Union[Unset, int] = UNSET,
+    force_reload: Union[Unset, bool] = False,
+    x_runtime_actions: Union[Unset, str] = UNSET,
+) -> Optional[str]:
+    """Push new haproxy configuration
+
+     Push a new haproxy configuration file in plain text
+
+    Args:
+        skip_version (Union[Unset, bool]):  Default: False.
+        skip_reload (Union[Unset, bool]):  Default: False.
+        only_validate (Union[Unset, bool]):  Default: False.
+        version (Union[Unset, int]):
+        force_reload (Union[Unset, bool]):  Default: False.
+        x_runtime_actions (Union[Unset, str]):
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        str
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        skip_version=skip_version,
+        skip_reload=skip_reload,
+        only_validate=only_validate,
+        version=version,
+        force_reload=force_reload,
+        x_runtime_actions=x_runtime_actions,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_version: Union[Unset, bool] = False,
+    skip_reload: Union[Unset, bool] = False,
+    only_validate: Union[Unset, bool] = False,
+    version: Union[Unset, int] = UNSET,
+    force_reload: Union[Unset, bool] = False,
+    x_runtime_actions: Union[Unset, str] = UNSET,
+) -> Response[str]:
+    """Push new haproxy configuration
+
+     Push a new haproxy configuration file in plain text
+
+    Args:
+        skip_version (Union[Unset, bool]):  Default: False.
+        skip_reload (Union[Unset, bool]):  Default: False.
+        only_validate (Union[Unset, bool]):  Default: False.
+        version (Union[Unset, int]):
+        force_reload (Union[Unset, bool]):  Default: False.
+        x_runtime_actions (Union[Unset, str]):
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[str]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        skip_version=skip_version,
+        skip_reload=skip_reload,
+        only_validate=only_validate,
+        version=version,
+        force_reload=force_reload,
+        x_runtime_actions=x_runtime_actions,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_version: Union[Unset, bool] = False,
+    skip_reload: Union[Unset, bool] = False,
+    only_validate: Union[Unset, bool] = False,
+    version: Union[Unset, int] = UNSET,
+    force_reload: Union[Unset, bool] = False,
+    x_runtime_actions: Union[Unset, str] = UNSET,
+) -> Optional[str]:
+    """Push new haproxy configuration
+
+     Push a new haproxy configuration file in plain text
+
+    Args:
+        skip_version (Union[Unset, bool]):  Default: False.
+        skip_reload (Union[Unset, bool]):  Default: False.
+        only_validate (Union[Unset, bool]):  Default: False.
+        version (Union[Unset, int]):
+        force_reload (Union[Unset, bool]):  Default: False.
+        x_runtime_actions (Union[Unset, str]):
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        str
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            skip_version=skip_version,
+            skip_reload=skip_reload,
+            only_validate=only_validate,
+            version=version,
+            force_reload=force_reload,
+            x_runtime_actions=x_runtime_actions,
+        )
+    ).parsed

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_load/create_crt_load.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_load/create_crt_load.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.certificate_load_action import CertificateLoadAction
 from ...models.error import Error
@@ -38,9 +37,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -49,27 +47,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[CertificateLoadAction, Error]]:
+) -> Union[CertificateLoadAction, Error]:
     if response.status_code == 201:
         response_201 = CertificateLoadAction.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = CertificateLoadAction.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_load/delete_crt_load.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_load/delete_crt_load.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -38,23 +37,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_load/get_crt_load.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_load/get_crt_load.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.certificate_load_action import CertificateLoadAction
 from ...models.error import Error
@@ -35,19 +34,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[CertificateLoadAction, Error]]:
+) -> Union[CertificateLoadAction, Error]:
     if response.status_code == 200:
         response_200 = CertificateLoadAction.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_load/get_crt_loads.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_load/get_crt_loads.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.certificate_load_action import CertificateLoadAction
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -33,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["CertificateLoadAction"]]:
+) -> Union[Error, list["CertificateLoadAction"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemascrt_loads_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["CertificateLoadAction"]]:
+) -> Response[Union[Error, list["CertificateLoadAction"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     crt_store: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["CertificateLoadAction"]]:
+) -> Response[Union[Error, list["CertificateLoadAction"]]]:
     """Return an array of loaded certificates
 
      Returns the list of loaded certificates from the specified crt_store
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['CertificateLoadAction']]
+        Response[Union[Error, list['CertificateLoadAction']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     crt_store: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["CertificateLoadAction"]]:
+) -> Optional[Union[Error, list["CertificateLoadAction"]]]:
     """Return an array of loaded certificates
 
      Returns the list of loaded certificates from the specified crt_store
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['CertificateLoadAction']
+        Union[Error, list['CertificateLoadAction']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     crt_store: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["CertificateLoadAction"]]:
+) -> Response[Union[Error, list["CertificateLoadAction"]]]:
     """Return an array of loaded certificates
 
      Returns the list of loaded certificates from the specified crt_store
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['CertificateLoadAction']]
+        Response[Union[Error, list['CertificateLoadAction']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     crt_store: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["CertificateLoadAction"]]:
+) -> Optional[Union[Error, list["CertificateLoadAction"]]]:
     """Return an array of loaded certificates
 
      Returns the list of loaded certificates from the specified crt_store
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['CertificateLoadAction']
+        Union[Error, list['CertificateLoadAction']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_load/replace_crt_load.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_load/replace_crt_load.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.certificate_load_action import CertificateLoadAction
 from ...models.error import Error
@@ -39,9 +38,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,27 +48,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[CertificateLoadAction, Error]]:
+) -> Union[CertificateLoadAction, Error]:
     if response.status_code == 200:
         response_200 = CertificateLoadAction.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = CertificateLoadAction.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_store/create_crt_store.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_store/create_crt_store.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.certificate_store import CertificateStore
 from ...models.error import Error
@@ -35,9 +34,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -46,27 +44,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[CertificateStore, Error]]:
+) -> Union[CertificateStore, Error]:
     if response.status_code == 201:
         response_201 = CertificateStore.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = CertificateStore.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_store/delete_crt_store.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_store/delete_crt_store.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_store/edit_crt_store.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_store/edit_crt_store.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.certificate_store import CertificateStore
 from ...models.error import Error
@@ -36,9 +35,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -47,27 +45,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[CertificateStore, Error]]:
+) -> Union[CertificateStore, Error]:
     if response.status_code == 200:
         response_200 = CertificateStore.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = CertificateStore.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_store/get_crt_store.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_store/get_crt_store.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.certificate_store import CertificateStore
 from ...models.error import Error
@@ -32,19 +31,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[CertificateStore, Error]]:
+) -> Union[CertificateStore, Error]:
     if response.status_code == 200:
         response_200 = CertificateStore.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_store/get_crt_stores.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/crt_store/get_crt_stores.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.certificate_store import CertificateStore
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -30,7 +30,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["CertificateStore"]]:
+) -> Union[Error, list["CertificateStore"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -40,15 +40,15 @@ def _parse_response(
             response_200.append(componentsschemascrt_stores_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["CertificateStore"]]:
+) -> Response[Union[Error, list["CertificateStore"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -61,7 +61,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["CertificateStore"]]:
+) -> Response[Union[Error, list["CertificateStore"]]]:
     """Return all the Certificate Stores
 
      Returns an array of all the configured crt_store sections in HAProxy
@@ -74,7 +74,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['CertificateStore']]
+        Response[Union[Error, list['CertificateStore']]]
     """
 
     kwargs = _get_kwargs(
@@ -92,7 +92,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["CertificateStore"]]:
+) -> Optional[Union[Error, list["CertificateStore"]]]:
     """Return all the Certificate Stores
 
      Returns an array of all the configured crt_store sections in HAProxy
@@ -105,7 +105,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['CertificateStore']
+        Union[Error, list['CertificateStore']]
     """
 
     return sync_detailed(
@@ -118,7 +118,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["CertificateStore"]]:
+) -> Response[Union[Error, list["CertificateStore"]]]:
     """Return all the Certificate Stores
 
      Returns an array of all the configured crt_store sections in HAProxy
@@ -131,7 +131,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['CertificateStore']]
+        Response[Union[Error, list['CertificateStore']]]
     """
 
     kwargs = _get_kwargs(
@@ -147,7 +147,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["CertificateStore"]]:
+) -> Optional[Union[Error, list["CertificateStore"]]]:
     """Return all the Certificate Stores
 
      Returns an array of all the configured crt_store sections in HAProxy
@@ -160,7 +160,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['CertificateStore']
+        Union[Error, list['CertificateStore']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/declare_capture/create_declare_capture.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/declare_capture/create_declare_capture.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.declare_capture import DeclareCapture
 from ...models.error import Error
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[DeclareCapture, Error]]:
+) -> Union[DeclareCapture, Error]:
     if response.status_code == 201:
         response_201 = DeclareCapture.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = DeclareCapture.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/declare_capture/delete_declare_capture.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/declare_capture/delete_declare_capture.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/declare_capture/get_declare_capture.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/declare_capture/get_declare_capture.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.declare_capture import DeclareCapture
 from ...models.error import Error
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[DeclareCapture, Error]]:
+) -> Union[DeclareCapture, Error]:
     if response.status_code == 200:
         response_200 = DeclareCapture.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/declare_capture/get_declare_captures.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/declare_capture/get_declare_captures.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.declare_capture import DeclareCapture
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["DeclareCapture"]]:
+) -> Union[Error, list["DeclareCapture"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemascaptures_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["DeclareCapture"]]:
+) -> Response[Union[Error, list["DeclareCapture"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["DeclareCapture"]]:
+) -> Response[Union[Error, list["DeclareCapture"]]]:
     """Return an array of declare captures
 
      Returns an array of all declare capture records that are configured in specified frontend.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['DeclareCapture']]
+        Response[Union[Error, list['DeclareCapture']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["DeclareCapture"]]:
+) -> Optional[Union[Error, list["DeclareCapture"]]]:
     """Return an array of declare captures
 
      Returns an array of all declare capture records that are configured in specified frontend.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['DeclareCapture']
+        Union[Error, list['DeclareCapture']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["DeclareCapture"]]:
+) -> Response[Union[Error, list["DeclareCapture"]]]:
     """Return an array of declare captures
 
      Returns an array of all declare capture records that are configured in specified frontend.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['DeclareCapture']]
+        Response[Union[Error, list['DeclareCapture']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["DeclareCapture"]]:
+) -> Optional[Union[Error, list["DeclareCapture"]]]:
     """Return an array of declare captures
 
      Returns an array of all declare capture records that are configured in specified frontend.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['DeclareCapture']
+        Union[Error, list['DeclareCapture']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/declare_capture/replace_declare_capture.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/declare_capture/replace_declare_capture.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.declare_capture import DeclareCapture
 from ...models.error import Error
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[DeclareCapture, Error]]:
+) -> Union[DeclareCapture, Error]:
     if response.status_code == 200:
         response_200 = DeclareCapture.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = DeclareCapture.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/declare_capture/replace_declare_captures.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/declare_capture/replace_declare_captures.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.declare_capture import DeclareCapture
 from ...models.error import Error
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemascaptures_item_data in body:
         componentsschemascaptures_item = componentsschemascaptures_item_data.to_dict()
-        _body.append(componentsschemascaptures_item)
+        _kwargs["json"].append(componentsschemascaptures_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["DeclareCapture"]]]:
+) -> Union[Error, list["DeclareCapture"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemascaptures_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemascaptures_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/defaults/add_defaults_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/defaults/add_defaults_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.defaults import Defaults
 from ...models.error import Error
@@ -38,38 +37,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Defaults, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Defaults, Error]:
     if response.status_code == 201:
         response_201 = Defaults.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Defaults.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/defaults/create_defaults_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/defaults/create_defaults_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.defaults import Defaults
 from ...models.error import Error
@@ -38,38 +37,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Defaults, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Defaults, Error]:
     if response.status_code == 201:
         response_201 = Defaults.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Defaults.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/defaults/delete_defaults_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/defaults/delete_defaults_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -38,23 +37,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/defaults/get_defaults_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/defaults/get_defaults_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.defaults import Defaults
 from ...models.error import Error
@@ -33,21 +32,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Defaults, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Defaults, Error]:
     if response.status_code == 200:
         response_200 = Defaults.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/defaults/get_defaults_sections.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/defaults/get_defaults_sections.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.defaults import Defaults
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -33,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Defaults"]]:
+) -> Union[Error, list["Defaults"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasdefaults_sections_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Defaults"]]:
+) -> Response[Union[Error, list["Defaults"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["Defaults"]]:
+) -> Response[Union[Error, list["Defaults"]]]:
     """Return an array of defaults
 
      Returns an array of all configured defaults.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Defaults']]
+        Response[Union[Error, list['Defaults']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["Defaults"]]:
+) -> Optional[Union[Error, list["Defaults"]]]:
     """Return an array of defaults
 
      Returns an array of all configured defaults.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Defaults']
+        Union[Error, list['Defaults']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["Defaults"]]:
+) -> Response[Union[Error, list["Defaults"]]]:
     """Return an array of defaults
 
      Returns an array of all configured defaults.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Defaults']]
+        Response[Union[Error, list['Defaults']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["Defaults"]]:
+) -> Optional[Union[Error, list["Defaults"]]]:
     """Return an array of defaults
 
      Returns an array of all configured defaults.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Defaults']
+        Union[Error, list['Defaults']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/defaults/replace_defaults_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/defaults/replace_defaults_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.defaults import Defaults
 from ...models.error import Error
@@ -39,38 +38,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Defaults, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Defaults, Error]:
     if response.status_code == 200:
         response_200 = Defaults.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Defaults.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/dgram_bind/create_dgram_bind.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/dgram_bind/create_dgram_bind.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.dgram_bind import DgramBind
 from ...models.error import Error
@@ -36,38 +35,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[DgramBind, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[DgramBind, Error]:
     if response.status_code == 201:
         response_201 = DgramBind.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = DgramBind.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/dgram_bind/delete_dgram_bind.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/dgram_bind/delete_dgram_bind.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/dgram_bind/get_dgram_bind.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/dgram_bind/get_dgram_bind.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.dgram_bind import DgramBind
 from ...models.error import Error
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[DgramBind, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[DgramBind, Error]:
     if response.status_code == 200:
         response_200 = DgramBind.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/dgram_bind/get_dgram_binds.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/dgram_bind/get_dgram_binds.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.dgram_bind import DgramBind
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["DgramBind"]]:
+) -> Union[Error, list["DgramBind"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemasdgram_binds_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["DgramBind"]]:
+) -> Response[Union[Error, list["DgramBind"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["DgramBind"]]:
+) -> Response[Union[Error, list["DgramBind"]]]:
     """Return an array of dgram binds
 
      Returns an array of all dgram binds that are configured in specified log forward.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['DgramBind']]
+        Response[Union[Error, list['DgramBind']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["DgramBind"]]:
+) -> Optional[Union[Error, list["DgramBind"]]]:
     """Return an array of dgram binds
 
      Returns an array of all dgram binds that are configured in specified log forward.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['DgramBind']
+        Union[Error, list['DgramBind']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["DgramBind"]]:
+) -> Response[Union[Error, list["DgramBind"]]]:
     """Return an array of dgram binds
 
      Returns an array of all dgram binds that are configured in specified log forward.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['DgramBind']]
+        Response[Union[Error, list['DgramBind']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["DgramBind"]]:
+) -> Optional[Union[Error, list["DgramBind"]]]:
     """Return an array of dgram binds
 
      Returns an array of all dgram binds that are configured in specified log forward.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['DgramBind']
+        Union[Error, list['DgramBind']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/dgram_bind/replace_dgram_bind.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/dgram_bind/replace_dgram_bind.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.dgram_bind import DgramBind
 from ...models.error import Error
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[DgramBind, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[DgramBind, Error]:
     if response.status_code == 200:
         response_200 = DgramBind.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = DgramBind.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_api_endpoints.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_api_endpoints.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.endpoint import Endpoint
+from ...models.error import Error
 from ...types import Response
 
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Endpoint"]]:
+) -> Union[Error, list["Endpoint"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasendpoints_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of root endpoints
 
      Returns a list of root endpoints.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of root endpoints
 
      Returns a list of root endpoints.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of root endpoints
 
      Returns a list of root endpoints.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of root endpoints
 
      Returns a list of root endpoints.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_configuration_endpoints.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_configuration_endpoints.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.endpoint import Endpoint
+from ...models.error import Error
 from ...types import Response
 
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Endpoint"]]:
+) -> Union[Error, list["Endpoint"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasendpoints_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy advanced configuration endpoints
 
      Returns a list of endpoints to be used for advanced configuration of HAProxy objects.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy advanced configuration endpoints
 
      Returns a list of endpoints to be used for advanced configuration of HAProxy objects.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy advanced configuration endpoints
 
      Returns a list of endpoints to be used for advanced configuration of HAProxy objects.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy advanced configuration endpoints
 
      Returns a list of endpoints to be used for advanced configuration of HAProxy objects.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_haproxy_endpoints.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_haproxy_endpoints.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.endpoint import Endpoint
+from ...models.error import Error
 from ...types import Response
 
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Endpoint"]]:
+) -> Union[Error, list["Endpoint"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasendpoints_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy related endpoints
 
      Returns a list of HAProxy related endpoints.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy related endpoints
 
      Returns a list of HAProxy related endpoints.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy related endpoints
 
      Returns a list of HAProxy related endpoints.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy related endpoints
 
      Returns a list of HAProxy related endpoints.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_runtime_endpoints.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_runtime_endpoints.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.endpoint import Endpoint
+from ...models.error import Error
 from ...types import Response
 
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Endpoint"]]:
+) -> Union[Error, list["Endpoint"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasendpoints_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy advanced runtime endpoints
 
      Returns a list of endpoints to be used for advanced runtime settings of HAProxy objects.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy advanced runtime endpoints
 
      Returns a list of endpoints to be used for advanced runtime settings of HAProxy objects.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy advanced runtime endpoints
 
      Returns a list of endpoints to be used for advanced runtime settings of HAProxy objects.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy advanced runtime endpoints
 
      Returns a list of endpoints to be used for advanced runtime settings of HAProxy objects.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_services_endpoints.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_services_endpoints.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.endpoint import Endpoint
+from ...models.error import Error
 from ...types import Response
 
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Endpoint"]]:
+) -> Union[Error, list["Endpoint"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasendpoints_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of service endpoints
 
      Returns a list of API managed services endpoints.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of service endpoints
 
      Returns a list of API managed services endpoints.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of service endpoints
 
      Returns a list of API managed services endpoints.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of service endpoints
 
      Returns a list of API managed services endpoints.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_spoe_endpoints.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_spoe_endpoints.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.endpoint import Endpoint
+from ...models.error import Error
 from ...types import Response
 
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Endpoint"]]:
+) -> Union[Error, list["Endpoint"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasendpoints_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy SPOE endpoints
 
      Returns a list of endpoints to be used for SPOE settings of HAProxy.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy SPOE endpoints
 
      Returns a list of endpoints to be used for SPOE settings of HAProxy.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy SPOE endpoints
 
      Returns a list of endpoints to be used for SPOE settings of HAProxy.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy SPOE endpoints
 
      Returns a list of endpoints to be used for SPOE settings of HAProxy.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_stats_endpoints.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_stats_endpoints.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.endpoint import Endpoint
+from ...models.error import Error
 from ...types import Response
 
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Endpoint"]]:
+) -> Union[Error, list["Endpoint"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasendpoints_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy stats endpoints
 
      Returns a list of HAProxy stats endpoints.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy stats endpoints
 
      Returns a list of HAProxy stats endpoints.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy stats endpoints
 
      Returns a list of HAProxy stats endpoints.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy stats endpoints
 
      Returns a list of HAProxy stats endpoints.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_storage_endpoints.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/discovery/get_storage_endpoints.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.endpoint import Endpoint
+from ...models.error import Error
 from ...types import Response
 
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Endpoint"]]:
+) -> Union[Error, list["Endpoint"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasendpoints_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy storage endpoints
 
      Returns a list of endpoints that use HAProxy storage for persistency, e.g. maps, ssl certificates...
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy storage endpoints
 
      Returns a list of endpoints that use HAProxy storage for persistency, e.g. maps, ssl certificates...
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["Endpoint"]]:
+) -> Response[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy storage endpoints
 
      Returns a list of endpoints that use HAProxy storage for persistency, e.g. maps, ssl certificates...
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Endpoint']]
+        Response[Union[Error, list['Endpoint']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["Endpoint"]]:
+) -> Optional[Union[Error, list["Endpoint"]]]:
     """Return list of HAProxy storage endpoints
 
      Returns a list of endpoints that use HAProxy storage for persistency, e.g. maps, ssl certificates...
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Endpoint']
+        Union[Error, list['Endpoint']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/fcgi_app/create_fcgi_app.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/fcgi_app/create_fcgi_app.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.fcgi_app import FcgiApp
@@ -38,38 +37,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, FcgiApp]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, FcgiApp]:
     if response.status_code == 201:
         response_201 = FcgiApp.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = FcgiApp.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/fcgi_app/delete_fcgi_app.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/fcgi_app/delete_fcgi_app.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/fcgi_app/get_fcgi_app.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/fcgi_app/get_fcgi_app.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.fcgi_app import FcgiApp
@@ -33,21 +32,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, FcgiApp]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, FcgiApp]:
     if response.status_code == 200:
         response_200 = FcgiApp.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/fcgi_app/get_fcgi_apps.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/fcgi_app/get_fcgi_apps.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.fcgi_app import FcgiApp
 from ...types import UNSET, Response, Unset
 
@@ -33,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["FcgiApp"]]:
+) -> Union[Error, list["FcgiApp"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasfcgi_apps_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["FcgiApp"]]:
+) -> Response[Union[Error, list["FcgiApp"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["FcgiApp"]]:
+) -> Response[Union[Error, list["FcgiApp"]]]:
     """Return an array of FCGI apps
 
      Returns an array of all configured FCGI applications.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['FcgiApp']]
+        Response[Union[Error, list['FcgiApp']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["FcgiApp"]]:
+) -> Optional[Union[Error, list["FcgiApp"]]]:
     """Return an array of FCGI apps
 
      Returns an array of all configured FCGI applications.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['FcgiApp']
+        Union[Error, list['FcgiApp']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["FcgiApp"]]:
+) -> Response[Union[Error, list["FcgiApp"]]]:
     """Return an array of FCGI apps
 
      Returns an array of all configured FCGI applications.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['FcgiApp']]
+        Response[Union[Error, list['FcgiApp']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["FcgiApp"]]:
+) -> Optional[Union[Error, list["FcgiApp"]]]:
     """Return an array of FCGI apps
 
      Returns an array of all configured FCGI applications.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['FcgiApp']
+        Union[Error, list['FcgiApp']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/fcgi_app/replace_fcgi_app.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/fcgi_app/replace_fcgi_app.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.fcgi_app import FcgiApp
@@ -39,38 +38,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, FcgiApp]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, FcgiApp]:
     if response.status_code == 200:
         response_200 = FcgiApp.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = FcgiApp.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/create_filter_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/create_filter_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.filter_ import Filter
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Filter]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Filter]:
     if response.status_code == 201:
         response_201 = Filter.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Filter.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/create_filter_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/create_filter_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.filter_ import Filter
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Filter]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Filter]:
     if response.status_code == 201:
         response_201 = Filter.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Filter.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/delete_filter_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/delete_filter_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/delete_filter_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/delete_filter_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/get_all_filter_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/get_all_filter_backend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.filter_ import Filter
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Filter"]]:
+) -> Union[Error, list["Filter"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemasfilters_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Filter"]]:
+) -> Response[Union[Error, list["Filter"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Filter"]]:
+) -> Response[Union[Error, list["Filter"]]]:
     """Return an array of all Filters
 
      Returns all Filters that are configured in specified parent.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Filter']]
+        Response[Union[Error, list['Filter']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Filter"]]:
+) -> Optional[Union[Error, list["Filter"]]]:
     """Return an array of all Filters
 
      Returns all Filters that are configured in specified parent.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Filter']
+        Union[Error, list['Filter']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Filter"]]:
+) -> Response[Union[Error, list["Filter"]]]:
     """Return an array of all Filters
 
      Returns all Filters that are configured in specified parent.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Filter']]
+        Response[Union[Error, list['Filter']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Filter"]]:
+) -> Optional[Union[Error, list["Filter"]]]:
     """Return an array of all Filters
 
      Returns all Filters that are configured in specified parent.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Filter']
+        Union[Error, list['Filter']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/get_all_filter_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/get_all_filter_frontend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.filter_ import Filter
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Filter"]]:
+) -> Union[Error, list["Filter"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemasfilters_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Filter"]]:
+) -> Response[Union[Error, list["Filter"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Filter"]]:
+) -> Response[Union[Error, list["Filter"]]]:
     """Return an array of all Filters
 
      Returns all Filters that are configured in specified parent.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Filter']]
+        Response[Union[Error, list['Filter']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Filter"]]:
+) -> Optional[Union[Error, list["Filter"]]]:
     """Return an array of all Filters
 
      Returns all Filters that are configured in specified parent.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Filter']
+        Union[Error, list['Filter']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Filter"]]:
+) -> Response[Union[Error, list["Filter"]]]:
     """Return an array of all Filters
 
      Returns all Filters that are configured in specified parent.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Filter']]
+        Response[Union[Error, list['Filter']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Filter"]]:
+) -> Optional[Union[Error, list["Filter"]]]:
     """Return an array of all Filters
 
      Returns all Filters that are configured in specified parent.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Filter']
+        Union[Error, list['Filter']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/get_filter_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/get_filter_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.filter_ import Filter
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Filter]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Filter]:
     if response.status_code == 200:
         response_200 = Filter.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/get_filter_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/get_filter_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.filter_ import Filter
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Filter]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Filter]:
     if response.status_code == 200:
         response_200 = Filter.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/replace_all_filter_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/replace_all_filter_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.filter_ import Filter
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemasfilters_item_data in body:
         componentsschemasfilters_item = componentsschemasfilters_item_data.to_dict()
-        _body.append(componentsschemasfilters_item)
+        _kwargs["json"].append(componentsschemasfilters_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["Filter"]]]:
+) -> Union[Error, list["Filter"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemasfilters_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemasfilters_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/replace_all_filter_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/replace_all_filter_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.filter_ import Filter
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemasfilters_item_data in body:
         componentsschemasfilters_item = componentsschemasfilters_item_data.to_dict()
-        _body.append(componentsschemasfilters_item)
+        _kwargs["json"].append(componentsschemasfilters_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["Filter"]]]:
+) -> Union[Error, list["Filter"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemasfilters_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemasfilters_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/replace_filter_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/replace_filter_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.filter_ import Filter
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Filter]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Filter]:
     if response.status_code == 200:
         response_200 = Filter.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Filter.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/replace_filter_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/filter_/replace_filter_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.filter_ import Filter
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Filter]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Filter]:
     if response.status_code == 200:
         response_200 = Filter.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Filter.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/frontend/create_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/frontend/create_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.frontend import Frontend
@@ -38,38 +37,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Frontend]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Frontend]:
     if response.status_code == 201:
         response_201 = Frontend.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Frontend.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/frontend/delete_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/frontend/delete_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/frontend/get_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/frontend/get_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.frontend import Frontend
@@ -33,21 +32,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Frontend]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Frontend]:
     if response.status_code == 200:
         response_200 = Frontend.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/frontend/get_frontends.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/frontend/get_frontends.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.frontend import Frontend
 from ...types import UNSET, Response, Unset
 
@@ -33,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Frontend"]]:
+) -> Union[Error, list["Frontend"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasfrontends_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Frontend"]]:
+) -> Response[Union[Error, list["Frontend"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["Frontend"]]:
+) -> Response[Union[Error, list["Frontend"]]]:
     """Return an array of frontends
 
      Returns an array of all configured frontends.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Frontend']]
+        Response[Union[Error, list['Frontend']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["Frontend"]]:
+) -> Optional[Union[Error, list["Frontend"]]]:
     """Return an array of frontends
 
      Returns an array of all configured frontends.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Frontend']
+        Union[Error, list['Frontend']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["Frontend"]]:
+) -> Response[Union[Error, list["Frontend"]]]:
     """Return an array of frontends
 
      Returns an array of all configured frontends.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Frontend']]
+        Response[Union[Error, list['Frontend']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["Frontend"]]:
+) -> Optional[Union[Error, list["Frontend"]]]:
     """Return an array of frontends
 
      Returns an array of all configured frontends.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Frontend']
+        Union[Error, list['Frontend']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/frontend/replace_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/frontend/replace_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.frontend import Frontend
@@ -39,38 +38,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Frontend]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Frontend]:
     if response.status_code == 200:
         response_200 = Frontend.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Frontend.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/global_/get_global.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/global_/get_global.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.global_ import Global
 from ...types import UNSET, Response, Unset
 
@@ -31,18 +31,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Global]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Global]:
     if response.status_code == 200:
         response_200 = Global.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Global]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, Global]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -56,7 +58,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[Global]:
+) -> Response[Union[Error, Global]]:
     """Return a global part of configuration
 
      Returns global part of configuration.
@@ -70,7 +72,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Global]
+        Response[Union[Error, Global]]
     """
 
     kwargs = _get_kwargs(
@@ -90,7 +92,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[Global]:
+) -> Optional[Union[Error, Global]]:
     """Return a global part of configuration
 
      Returns global part of configuration.
@@ -104,7 +106,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Global
+        Union[Error, Global]
     """
 
     return sync_detailed(
@@ -119,7 +121,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[Global]:
+) -> Response[Union[Error, Global]]:
     """Return a global part of configuration
 
      Returns global part of configuration.
@@ -133,7 +135,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Global]
+        Response[Union[Error, Global]]
     """
 
     kwargs = _get_kwargs(
@@ -151,7 +153,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[Global]:
+) -> Optional[Union[Error, Global]]:
     """Return a global part of configuration
 
      Returns global part of configuration.
@@ -165,7 +167,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Global
+        Union[Error, Global]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/global_/replace_global.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/global_/replace_global.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.global_ import Global
@@ -38,34 +37,33 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Global]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Global]:
     if response.status_code == 200:
         response_200 = Global.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Global.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/group/create_group.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/group/create_group.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.group import Group
@@ -38,38 +37,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Group]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Group]:
     if response.status_code == 201:
         response_201 = Group.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Group.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/group/delete_group.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/group/delete_group.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -38,23 +37,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/group/get_group.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/group/get_group.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.group import Group
@@ -33,21 +32,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Group]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Group]:
     if response.status_code == 200:
         response_200 = Group.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/group/get_groups.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/group/get_groups.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.group import Group
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[list["Group"]]:
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Union[Error, list["Group"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,13 +43,15 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
             response_200.append(componentsschemasgroups_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[list["Group"]]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, list["Group"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -61,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     userlist: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Group"]]:
+) -> Response[Union[Error, list["Group"]]]:
     """Return an array of userlist groups
 
     Args:
@@ -73,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Group']]
+        Response[Union[Error, list['Group']]]
     """
 
     kwargs = _get_kwargs(
@@ -93,7 +97,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     userlist: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Group"]]:
+) -> Optional[Union[Error, list["Group"]]]:
     """Return an array of userlist groups
 
     Args:
@@ -105,7 +109,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Group']
+        Union[Error, list['Group']]
     """
 
     return sync_detailed(
@@ -120,7 +124,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     userlist: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Group"]]:
+) -> Response[Union[Error, list["Group"]]]:
     """Return an array of userlist groups
 
     Args:
@@ -132,7 +136,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Group']]
+        Response[Union[Error, list['Group']]]
     """
 
     kwargs = _get_kwargs(
@@ -150,7 +154,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     userlist: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Group"]]:
+) -> Optional[Union[Error, list["Group"]]]:
     """Return an array of userlist groups
 
     Args:
@@ -162,7 +166,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Group']
+        Union[Error, list['Group']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/group/replace_group.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/group/replace_group.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.group import Group
@@ -39,38 +38,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Group]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Group]:
     if response.status_code == 200:
         response_200 = Group.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Group.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/health/get_health.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/health/get_health.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.health import Health
 from ...types import Response
 
@@ -18,18 +18,20 @@ def _get_kwargs() -> dict[str, Any]:
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Health]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Health]:
     if response.status_code == 200:
         response_200 = Health.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Health]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, Health]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -41,7 +43,7 @@ def _build_response(*, client: Union[AuthenticatedClient, Client], response: htt
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[Health]:
+) -> Response[Union[Error, Health]]:
     """Return managed services health
 
      Return managed services health
@@ -51,7 +53,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Health]
+        Response[Union[Error, Health]]
     """
 
     kwargs = _get_kwargs()
@@ -66,7 +68,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[Health]:
+) -> Optional[Union[Error, Health]]:
     """Return managed services health
 
      Return managed services health
@@ -76,7 +78,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Health
+        Union[Error, Health]
     """
 
     return sync_detailed(
@@ -87,7 +89,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[Health]:
+) -> Response[Union[Error, Health]]:
     """Return managed services health
 
      Return managed services health
@@ -97,7 +99,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Health]
+        Response[Union[Error, Health]]
     """
 
     kwargs = _get_kwargs()
@@ -110,7 +112,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[Health]:
+) -> Optional[Union[Error, Health]]:
     """Return managed services health
 
      Return managed services health
@@ -120,7 +122,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Health
+        Union[Error, Health]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/create_http_after_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/create_http_after_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPAfterResponseRule]]:
+) -> Union[Error, HTTPAfterResponseRule]:
     if response.status_code == 201:
         response_201 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/create_http_after_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/create_http_after_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPAfterResponseRule]]:
+) -> Union[Error, HTTPAfterResponseRule]:
     if response.status_code == 201:
         response_201 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/create_http_after_response_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/create_http_after_response_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPAfterResponseRule]]:
+) -> Union[Error, HTTPAfterResponseRule]:
     if response.status_code == 201:
         response_201 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/delete_http_after_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/delete_http_after_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/delete_http_after_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/delete_http_after_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/delete_http_after_response_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/delete_http_after_response_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/get_all_http_after_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/get_all_http_after_response_rule_backend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPAfterResponseRule"]]:
+) -> Union[Error, list["HTTPAfterResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_after_response_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPAfterResponseRule"]]:
+) -> Response[Union[Error, list["HTTPAfterResponseRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPAfterResponseRule"]]:
+) -> Response[Union[Error, list["HTTPAfterResponseRule"]]]:
     """Return an array of all HTTP After Response Rules
 
      Returns all HTTP After Response Rules that are configured in specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPAfterResponseRule']]
+        Response[Union[Error, list['HTTPAfterResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPAfterResponseRule"]]:
+) -> Optional[Union[Error, list["HTTPAfterResponseRule"]]]:
     """Return an array of all HTTP After Response Rules
 
      Returns all HTTP After Response Rules that are configured in specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPAfterResponseRule']
+        Union[Error, list['HTTPAfterResponseRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPAfterResponseRule"]]:
+) -> Response[Union[Error, list["HTTPAfterResponseRule"]]]:
     """Return an array of all HTTP After Response Rules
 
      Returns all HTTP After Response Rules that are configured in specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPAfterResponseRule']]
+        Response[Union[Error, list['HTTPAfterResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPAfterResponseRule"]]:
+) -> Optional[Union[Error, list["HTTPAfterResponseRule"]]]:
     """Return an array of all HTTP After Response Rules
 
      Returns all HTTP After Response Rules that are configured in specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPAfterResponseRule']
+        Union[Error, list['HTTPAfterResponseRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/get_all_http_after_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/get_all_http_after_response_rule_defaults.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPAfterResponseRule"]]:
+) -> Union[Error, list["HTTPAfterResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_after_response_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPAfterResponseRule"]]:
+) -> Response[Union[Error, list["HTTPAfterResponseRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPAfterResponseRule"]]:
+) -> Response[Union[Error, list["HTTPAfterResponseRule"]]]:
     """Return an array of all HTTP After Response Rules
 
      Returns all HTTP After Response Rules that are configured in specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPAfterResponseRule']]
+        Response[Union[Error, list['HTTPAfterResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPAfterResponseRule"]]:
+) -> Optional[Union[Error, list["HTTPAfterResponseRule"]]]:
     """Return an array of all HTTP After Response Rules
 
      Returns all HTTP After Response Rules that are configured in specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPAfterResponseRule']
+        Union[Error, list['HTTPAfterResponseRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPAfterResponseRule"]]:
+) -> Response[Union[Error, list["HTTPAfterResponseRule"]]]:
     """Return an array of all HTTP After Response Rules
 
      Returns all HTTP After Response Rules that are configured in specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPAfterResponseRule']]
+        Response[Union[Error, list['HTTPAfterResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPAfterResponseRule"]]:
+) -> Optional[Union[Error, list["HTTPAfterResponseRule"]]]:
     """Return an array of all HTTP After Response Rules
 
      Returns all HTTP After Response Rules that are configured in specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPAfterResponseRule']
+        Union[Error, list['HTTPAfterResponseRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/get_all_http_after_response_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/get_all_http_after_response_rule_frontend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPAfterResponseRule"]]:
+) -> Union[Error, list["HTTPAfterResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_after_response_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPAfterResponseRule"]]:
+) -> Response[Union[Error, list["HTTPAfterResponseRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPAfterResponseRule"]]:
+) -> Response[Union[Error, list["HTTPAfterResponseRule"]]]:
     """Return an array of all HTTP After Response Rules
 
      Returns all HTTP After Response Rules that are configured in specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPAfterResponseRule']]
+        Response[Union[Error, list['HTTPAfterResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPAfterResponseRule"]]:
+) -> Optional[Union[Error, list["HTTPAfterResponseRule"]]]:
     """Return an array of all HTTP After Response Rules
 
      Returns all HTTP After Response Rules that are configured in specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPAfterResponseRule']
+        Union[Error, list['HTTPAfterResponseRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPAfterResponseRule"]]:
+) -> Response[Union[Error, list["HTTPAfterResponseRule"]]]:
     """Return an array of all HTTP After Response Rules
 
      Returns all HTTP After Response Rules that are configured in specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPAfterResponseRule']]
+        Response[Union[Error, list['HTTPAfterResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPAfterResponseRule"]]:
+) -> Optional[Union[Error, list["HTTPAfterResponseRule"]]]:
     """Return an array of all HTTP After Response Rules
 
      Returns all HTTP After Response Rules that are configured in specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPAfterResponseRule']
+        Union[Error, list['HTTPAfterResponseRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/get_http_after_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/get_http_after_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPAfterResponseRule]]:
+) -> Union[Error, HTTPAfterResponseRule]:
     if response.status_code == 200:
         response_200 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/get_http_after_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/get_http_after_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPAfterResponseRule]]:
+) -> Union[Error, HTTPAfterResponseRule]:
     if response.status_code == 200:
         response_200 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/get_http_after_response_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/get_http_after_response_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPAfterResponseRule]]:
+) -> Union[Error, HTTPAfterResponseRule]:
     if response.status_code == 200:
         response_200 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/replace_all_http_after_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/replace_all_http_after_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_after_response_rules_item_data in body:
         componentsschemashttp_after_response_rules_item = componentsschemashttp_after_response_rules_item_data.to_dict()
-        _body.append(componentsschemashttp_after_response_rules_item)
+        _kwargs["json"].append(componentsschemashttp_after_response_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPAfterResponseRule"]]]:
+) -> Union[Error, list["HTTPAfterResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_after_response_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_after_response_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/replace_all_http_after_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/replace_all_http_after_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_after_response_rules_item_data in body:
         componentsschemashttp_after_response_rules_item = componentsschemashttp_after_response_rules_item_data.to_dict()
-        _body.append(componentsschemashttp_after_response_rules_item)
+        _kwargs["json"].append(componentsschemashttp_after_response_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPAfterResponseRule"]]]:
+) -> Union[Error, list["HTTPAfterResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_after_response_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_after_response_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/replace_all_http_after_response_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/replace_all_http_after_response_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_after_response_rules_item_data in body:
         componentsschemashttp_after_response_rules_item = componentsschemashttp_after_response_rules_item_data.to_dict()
-        _body.append(componentsschemashttp_after_response_rules_item)
+        _kwargs["json"].append(componentsschemashttp_after_response_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPAfterResponseRule"]]]:
+) -> Union[Error, list["HTTPAfterResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_after_response_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_after_response_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/replace_http_after_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/replace_http_after_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPAfterResponseRule]]:
+) -> Union[Error, HTTPAfterResponseRule]:
     if response.status_code == 200:
         response_200 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/replace_http_after_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/replace_http_after_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPAfterResponseRule]]:
+) -> Union[Error, HTTPAfterResponseRule]:
     if response.status_code == 200:
         response_200 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/replace_http_after_response_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_after_response_rule/replace_http_after_response_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_after_response_rule import HTTPAfterResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPAfterResponseRule]]:
+) -> Union[Error, HTTPAfterResponseRule]:
     if response.status_code == 200:
         response_200 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPAfterResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/create_http_check_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/create_http_check_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_check import HTTPCheck
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPCheck]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, HTTPCheck]:
     if response.status_code == 201:
         response_201 = HTTPCheck.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPCheck.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/create_http_check_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/create_http_check_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_check import HTTPCheck
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPCheck]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, HTTPCheck]:
     if response.status_code == 201:
         response_201 = HTTPCheck.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPCheck.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/delete_http_check_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/delete_http_check_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/delete_http_check_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/delete_http_check_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/get_all_http_check_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/get_all_http_check_backend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_check import HTTPCheck
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPCheck"]]:
+) -> Union[Error, list["HTTPCheck"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_checks_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPCheck"]]:
+) -> Response[Union[Error, list["HTTPCheck"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPCheck"]]:
+) -> Response[Union[Error, list["HTTPCheck"]]]:
     """Return an array of HTTP checks
 
      Returns all HTTP checks that are configured in specified parent.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPCheck']]
+        Response[Union[Error, list['HTTPCheck']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPCheck"]]:
+) -> Optional[Union[Error, list["HTTPCheck"]]]:
     """Return an array of HTTP checks
 
      Returns all HTTP checks that are configured in specified parent.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPCheck']
+        Union[Error, list['HTTPCheck']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPCheck"]]:
+) -> Response[Union[Error, list["HTTPCheck"]]]:
     """Return an array of HTTP checks
 
      Returns all HTTP checks that are configured in specified parent.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPCheck']]
+        Response[Union[Error, list['HTTPCheck']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPCheck"]]:
+) -> Optional[Union[Error, list["HTTPCheck"]]]:
     """Return an array of HTTP checks
 
      Returns all HTTP checks that are configured in specified parent.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPCheck']
+        Union[Error, list['HTTPCheck']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/get_all_http_check_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/get_all_http_check_defaults.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_check import HTTPCheck
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPCheck"]]:
+) -> Union[Error, list["HTTPCheck"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_checks_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPCheck"]]:
+) -> Response[Union[Error, list["HTTPCheck"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPCheck"]]:
+) -> Response[Union[Error, list["HTTPCheck"]]]:
     """Return an array of HTTP checks
 
      Returns all HTTP checks that are configured in specified parent.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPCheck']]
+        Response[Union[Error, list['HTTPCheck']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPCheck"]]:
+) -> Optional[Union[Error, list["HTTPCheck"]]]:
     """Return an array of HTTP checks
 
      Returns all HTTP checks that are configured in specified parent.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPCheck']
+        Union[Error, list['HTTPCheck']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPCheck"]]:
+) -> Response[Union[Error, list["HTTPCheck"]]]:
     """Return an array of HTTP checks
 
      Returns all HTTP checks that are configured in specified parent.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPCheck']]
+        Response[Union[Error, list['HTTPCheck']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPCheck"]]:
+) -> Optional[Union[Error, list["HTTPCheck"]]]:
     """Return an array of HTTP checks
 
      Returns all HTTP checks that are configured in specified parent.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPCheck']
+        Union[Error, list['HTTPCheck']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/get_http_check_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/get_http_check_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_check import HTTPCheck
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPCheck]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, HTTPCheck]:
     if response.status_code == 200:
         response_200 = HTTPCheck.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/get_http_check_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/get_http_check_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_check import HTTPCheck
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPCheck]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, HTTPCheck]:
     if response.status_code == 200:
         response_200 = HTTPCheck.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/replace_all_http_check_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/replace_all_http_check_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_check import HTTPCheck
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_checks_item_data in body:
         componentsschemashttp_checks_item = componentsschemashttp_checks_item_data.to_dict()
-        _body.append(componentsschemashttp_checks_item)
+        _kwargs["json"].append(componentsschemashttp_checks_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPCheck"]]]:
+) -> Union[Error, list["HTTPCheck"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_checks_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_checks_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/replace_all_http_check_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/replace_all_http_check_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_check import HTTPCheck
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_checks_item_data in body:
         componentsschemashttp_checks_item = componentsschemashttp_checks_item_data.to_dict()
-        _body.append(componentsschemashttp_checks_item)
+        _kwargs["json"].append(componentsschemashttp_checks_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPCheck"]]]:
+) -> Union[Error, list["HTTPCheck"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_checks_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_checks_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/replace_http_check_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/replace_http_check_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_check import HTTPCheck
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPCheck]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, HTTPCheck]:
     if response.status_code == 200:
         response_200 = HTTPCheck.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPCheck.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/replace_http_check_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_check/replace_http_check_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_check import HTTPCheck
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPCheck]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, HTTPCheck]:
     if response.status_code == 200:
         response_200 = HTTPCheck.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPCheck.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/create_http_error_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/create_http_error_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPErrorRule]]:
+) -> Union[Error, HTTPErrorRule]:
     if response.status_code == 201:
         response_201 = HTTPErrorRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPErrorRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/create_http_error_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/create_http_error_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPErrorRule]]:
+) -> Union[Error, HTTPErrorRule]:
     if response.status_code == 201:
         response_201 = HTTPErrorRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPErrorRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/create_http_error_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/create_http_error_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPErrorRule]]:
+) -> Union[Error, HTTPErrorRule]:
     if response.status_code == 201:
         response_201 = HTTPErrorRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPErrorRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/delete_http_error_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/delete_http_error_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/delete_http_error_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/delete_http_error_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/delete_http_error_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/delete_http_error_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/get_all_http_error_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/get_all_http_error_rule_backend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPErrorRule"]]:
+) -> Union[Error, list["HTTPErrorRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_error_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPErrorRule"]]:
+) -> Response[Union[Error, list["HTTPErrorRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPErrorRule"]]:
+) -> Response[Union[Error, list["HTTPErrorRule"]]]:
     """Return an array of all HTTP Error Rules
 
      Returns all HTTP Error Rules that are configured in the specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPErrorRule']]
+        Response[Union[Error, list['HTTPErrorRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPErrorRule"]]:
+) -> Optional[Union[Error, list["HTTPErrorRule"]]]:
     """Return an array of all HTTP Error Rules
 
      Returns all HTTP Error Rules that are configured in the specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPErrorRule']
+        Union[Error, list['HTTPErrorRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPErrorRule"]]:
+) -> Response[Union[Error, list["HTTPErrorRule"]]]:
     """Return an array of all HTTP Error Rules
 
      Returns all HTTP Error Rules that are configured in the specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPErrorRule']]
+        Response[Union[Error, list['HTTPErrorRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPErrorRule"]]:
+) -> Optional[Union[Error, list["HTTPErrorRule"]]]:
     """Return an array of all HTTP Error Rules
 
      Returns all HTTP Error Rules that are configured in the specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPErrorRule']
+        Union[Error, list['HTTPErrorRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/get_all_http_error_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/get_all_http_error_rule_defaults.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPErrorRule"]]:
+) -> Union[Error, list["HTTPErrorRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_error_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPErrorRule"]]:
+) -> Response[Union[Error, list["HTTPErrorRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPErrorRule"]]:
+) -> Response[Union[Error, list["HTTPErrorRule"]]]:
     """Return an array of all HTTP Error Rules
 
      Returns all HTTP Error Rules that are configured in the specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPErrorRule']]
+        Response[Union[Error, list['HTTPErrorRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPErrorRule"]]:
+) -> Optional[Union[Error, list["HTTPErrorRule"]]]:
     """Return an array of all HTTP Error Rules
 
      Returns all HTTP Error Rules that are configured in the specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPErrorRule']
+        Union[Error, list['HTTPErrorRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPErrorRule"]]:
+) -> Response[Union[Error, list["HTTPErrorRule"]]]:
     """Return an array of all HTTP Error Rules
 
      Returns all HTTP Error Rules that are configured in the specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPErrorRule']]
+        Response[Union[Error, list['HTTPErrorRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPErrorRule"]]:
+) -> Optional[Union[Error, list["HTTPErrorRule"]]]:
     """Return an array of all HTTP Error Rules
 
      Returns all HTTP Error Rules that are configured in the specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPErrorRule']
+        Union[Error, list['HTTPErrorRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/get_all_http_error_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/get_all_http_error_rule_frontend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPErrorRule"]]:
+) -> Union[Error, list["HTTPErrorRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_error_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPErrorRule"]]:
+) -> Response[Union[Error, list["HTTPErrorRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPErrorRule"]]:
+) -> Response[Union[Error, list["HTTPErrorRule"]]]:
     """Return an array of all HTTP Error Rules
 
      Returns all HTTP Error Rules that are configured in the specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPErrorRule']]
+        Response[Union[Error, list['HTTPErrorRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPErrorRule"]]:
+) -> Optional[Union[Error, list["HTTPErrorRule"]]]:
     """Return an array of all HTTP Error Rules
 
      Returns all HTTP Error Rules that are configured in the specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPErrorRule']
+        Union[Error, list['HTTPErrorRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPErrorRule"]]:
+) -> Response[Union[Error, list["HTTPErrorRule"]]]:
     """Return an array of all HTTP Error Rules
 
      Returns all HTTP Error Rules that are configured in the specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPErrorRule']]
+        Response[Union[Error, list['HTTPErrorRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPErrorRule"]]:
+) -> Optional[Union[Error, list["HTTPErrorRule"]]]:
     """Return an array of all HTTP Error Rules
 
      Returns all HTTP Error Rules that are configured in the specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPErrorRule']
+        Union[Error, list['HTTPErrorRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/get_http_error_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/get_http_error_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPErrorRule]]:
+) -> Union[Error, HTTPErrorRule]:
     if response.status_code == 200:
         response_200 = HTTPErrorRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/get_http_error_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/get_http_error_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPErrorRule]]:
+) -> Union[Error, HTTPErrorRule]:
     if response.status_code == 200:
         response_200 = HTTPErrorRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/get_http_error_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/get_http_error_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPErrorRule]]:
+) -> Union[Error, HTTPErrorRule]:
     if response.status_code == 200:
         response_200 = HTTPErrorRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/replace_all_http_error_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/replace_all_http_error_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_error_rules_item_data in body:
         componentsschemashttp_error_rules_item = componentsschemashttp_error_rules_item_data.to_dict()
-        _body.append(componentsschemashttp_error_rules_item)
+        _kwargs["json"].append(componentsschemashttp_error_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPErrorRule"]]]:
+) -> Union[Error, list["HTTPErrorRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_error_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_error_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/replace_all_http_error_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/replace_all_http_error_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_error_rules_item_data in body:
         componentsschemashttp_error_rules_item = componentsschemashttp_error_rules_item_data.to_dict()
-        _body.append(componentsschemashttp_error_rules_item)
+        _kwargs["json"].append(componentsschemashttp_error_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPErrorRule"]]]:
+) -> Union[Error, list["HTTPErrorRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_error_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_error_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/replace_all_http_error_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/replace_all_http_error_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_error_rules_item_data in body:
         componentsschemashttp_error_rules_item = componentsschemashttp_error_rules_item_data.to_dict()
-        _body.append(componentsschemashttp_error_rules_item)
+        _kwargs["json"].append(componentsschemashttp_error_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPErrorRule"]]]:
+) -> Union[Error, list["HTTPErrorRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_error_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_error_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/replace_http_error_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/replace_http_error_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPErrorRule]]:
+) -> Union[Error, HTTPErrorRule]:
     if response.status_code == 200:
         response_200 = HTTPErrorRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPErrorRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/replace_http_error_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/replace_http_error_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPErrorRule]]:
+) -> Union[Error, HTTPErrorRule]:
     if response.status_code == 200:
         response_200 = HTTPErrorRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPErrorRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/replace_http_error_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_error_rule/replace_http_error_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_error_rule import HTTPErrorRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPErrorRule]]:
+) -> Union[Error, HTTPErrorRule]:
     if response.status_code == 200:
         response_200 = HTTPErrorRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPErrorRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_errors/create_http_errors_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_errors/create_http_errors_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_errors_section import HttpErrorsSection
@@ -35,9 +34,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -46,27 +44,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HttpErrorsSection]]:
+) -> Union[Error, HttpErrorsSection]:
     if response.status_code == 201:
         response_201 = HttpErrorsSection.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HttpErrorsSection.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_errors/delete_http_errors_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_errors/delete_http_errors_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_errors/get_http_errors_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_errors/get_http_errors_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_errors_section import HttpErrorsSection
@@ -32,19 +31,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HttpErrorsSection]]:
+) -> Union[Error, HttpErrorsSection]:
     if response.status_code == 200:
         response_200 = HttpErrorsSection.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_errors/get_http_errors_sections.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_errors/get_http_errors_sections.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_errors_section import HttpErrorsSection
 from ...types import UNSET, Response, Unset
 
@@ -30,7 +30,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HttpErrorsSection"]]:
+) -> Union[Error, list["HttpErrorsSection"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -42,15 +42,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_errors_sections_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HttpErrorsSection"]]:
+) -> Response[Union[Error, list["HttpErrorsSection"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HttpErrorsSection"]]:
+) -> Response[Union[Error, list["HttpErrorsSection"]]]:
     """Return an array of http-error sections
 
      Returns an array of all configured http-error sections.
@@ -76,7 +76,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HttpErrorsSection']]
+        Response[Union[Error, list['HttpErrorsSection']]]
     """
 
     kwargs = _get_kwargs(
@@ -94,7 +94,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HttpErrorsSection"]]:
+) -> Optional[Union[Error, list["HttpErrorsSection"]]]:
     """Return an array of http-error sections
 
      Returns an array of all configured http-error sections.
@@ -107,7 +107,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HttpErrorsSection']
+        Union[Error, list['HttpErrorsSection']]
     """
 
     return sync_detailed(
@@ -120,7 +120,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HttpErrorsSection"]]:
+) -> Response[Union[Error, list["HttpErrorsSection"]]]:
     """Return an array of http-error sections
 
      Returns an array of all configured http-error sections.
@@ -133,7 +133,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HttpErrorsSection']]
+        Response[Union[Error, list['HttpErrorsSection']]]
     """
 
     kwargs = _get_kwargs(
@@ -149,7 +149,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HttpErrorsSection"]]:
+) -> Optional[Union[Error, list["HttpErrorsSection"]]]:
     """Return an array of http-error sections
 
      Returns an array of all configured http-error sections.
@@ -162,7 +162,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HttpErrorsSection']
+        Union[Error, list['HttpErrorsSection']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_errors/replace_http_errors_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_errors/replace_http_errors_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_errors_section import HttpErrorsSection
@@ -36,9 +35,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -47,27 +45,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HttpErrorsSection]]:
+) -> Union[Error, HttpErrorsSection]:
     if response.status_code == 200:
         response_200 = HttpErrorsSection.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HttpErrorsSection.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/create_http_request_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/create_http_request_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPRequestRule]]:
+) -> Union[Error, HTTPRequestRule]:
     if response.status_code == 201:
         response_201 = HTTPRequestRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPRequestRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/create_http_request_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/create_http_request_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPRequestRule]]:
+) -> Union[Error, HTTPRequestRule]:
     if response.status_code == 201:
         response_201 = HTTPRequestRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPRequestRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/create_http_request_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/create_http_request_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPRequestRule]]:
+) -> Union[Error, HTTPRequestRule]:
     if response.status_code == 201:
         response_201 = HTTPRequestRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPRequestRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/delete_http_request_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/delete_http_request_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/delete_http_request_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/delete_http_request_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/delete_http_request_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/delete_http_request_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/get_all_http_request_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/get_all_http_request_rule_backend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPRequestRule"]]:
+) -> Union[Error, list["HTTPRequestRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_request_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPRequestRule"]]:
+) -> Response[Union[Error, list["HTTPRequestRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPRequestRule"]]:
+) -> Response[Union[Error, list["HTTPRequestRule"]]]:
     """Return an array of all HTTP Request Rules
 
      Returns all HTTP Request Rules that are configured in specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPRequestRule']]
+        Response[Union[Error, list['HTTPRequestRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPRequestRule"]]:
+) -> Optional[Union[Error, list["HTTPRequestRule"]]]:
     """Return an array of all HTTP Request Rules
 
      Returns all HTTP Request Rules that are configured in specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPRequestRule']
+        Union[Error, list['HTTPRequestRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPRequestRule"]]:
+) -> Response[Union[Error, list["HTTPRequestRule"]]]:
     """Return an array of all HTTP Request Rules
 
      Returns all HTTP Request Rules that are configured in specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPRequestRule']]
+        Response[Union[Error, list['HTTPRequestRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPRequestRule"]]:
+) -> Optional[Union[Error, list["HTTPRequestRule"]]]:
     """Return an array of all HTTP Request Rules
 
      Returns all HTTP Request Rules that are configured in specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPRequestRule']
+        Union[Error, list['HTTPRequestRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/get_all_http_request_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/get_all_http_request_rule_defaults.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPRequestRule"]]:
+) -> Union[Error, list["HTTPRequestRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_request_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPRequestRule"]]:
+) -> Response[Union[Error, list["HTTPRequestRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPRequestRule"]]:
+) -> Response[Union[Error, list["HTTPRequestRule"]]]:
     """Return an array of all HTTP Request Rules
 
      Returns all HTTP Request Rules that are configured in specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPRequestRule']]
+        Response[Union[Error, list['HTTPRequestRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPRequestRule"]]:
+) -> Optional[Union[Error, list["HTTPRequestRule"]]]:
     """Return an array of all HTTP Request Rules
 
      Returns all HTTP Request Rules that are configured in specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPRequestRule']
+        Union[Error, list['HTTPRequestRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPRequestRule"]]:
+) -> Response[Union[Error, list["HTTPRequestRule"]]]:
     """Return an array of all HTTP Request Rules
 
      Returns all HTTP Request Rules that are configured in specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPRequestRule']]
+        Response[Union[Error, list['HTTPRequestRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPRequestRule"]]:
+) -> Optional[Union[Error, list["HTTPRequestRule"]]]:
     """Return an array of all HTTP Request Rules
 
      Returns all HTTP Request Rules that are configured in specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPRequestRule']
+        Union[Error, list['HTTPRequestRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/get_all_http_request_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/get_all_http_request_rule_frontend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPRequestRule"]]:
+) -> Union[Error, list["HTTPRequestRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_request_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPRequestRule"]]:
+) -> Response[Union[Error, list["HTTPRequestRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPRequestRule"]]:
+) -> Response[Union[Error, list["HTTPRequestRule"]]]:
     """Return an array of all HTTP Request Rules
 
      Returns all HTTP Request Rules that are configured in specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPRequestRule']]
+        Response[Union[Error, list['HTTPRequestRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPRequestRule"]]:
+) -> Optional[Union[Error, list["HTTPRequestRule"]]]:
     """Return an array of all HTTP Request Rules
 
      Returns all HTTP Request Rules that are configured in specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPRequestRule']
+        Union[Error, list['HTTPRequestRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPRequestRule"]]:
+) -> Response[Union[Error, list["HTTPRequestRule"]]]:
     """Return an array of all HTTP Request Rules
 
      Returns all HTTP Request Rules that are configured in specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPRequestRule']]
+        Response[Union[Error, list['HTTPRequestRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPRequestRule"]]:
+) -> Optional[Union[Error, list["HTTPRequestRule"]]]:
     """Return an array of all HTTP Request Rules
 
      Returns all HTTP Request Rules that are configured in specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPRequestRule']
+        Union[Error, list['HTTPRequestRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/get_http_request_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/get_http_request_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPRequestRule]]:
+) -> Union[Error, HTTPRequestRule]:
     if response.status_code == 200:
         response_200 = HTTPRequestRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/get_http_request_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/get_http_request_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPRequestRule]]:
+) -> Union[Error, HTTPRequestRule]:
     if response.status_code == 200:
         response_200 = HTTPRequestRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/get_http_request_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/get_http_request_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPRequestRule]]:
+) -> Union[Error, HTTPRequestRule]:
     if response.status_code == 200:
         response_200 = HTTPRequestRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/replace_all_http_request_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/replace_all_http_request_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_request_rules_item_data in body:
         componentsschemashttp_request_rules_item = componentsschemashttp_request_rules_item_data.to_dict()
-        _body.append(componentsschemashttp_request_rules_item)
+        _kwargs["json"].append(componentsschemashttp_request_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPRequestRule"]]]:
+) -> Union[Error, list["HTTPRequestRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_request_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_request_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/replace_all_http_request_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/replace_all_http_request_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_request_rules_item_data in body:
         componentsschemashttp_request_rules_item = componentsschemashttp_request_rules_item_data.to_dict()
-        _body.append(componentsschemashttp_request_rules_item)
+        _kwargs["json"].append(componentsschemashttp_request_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPRequestRule"]]]:
+) -> Union[Error, list["HTTPRequestRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_request_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_request_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/replace_all_http_request_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/replace_all_http_request_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_request_rules_item_data in body:
         componentsschemashttp_request_rules_item = componentsschemashttp_request_rules_item_data.to_dict()
-        _body.append(componentsschemashttp_request_rules_item)
+        _kwargs["json"].append(componentsschemashttp_request_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPRequestRule"]]]:
+) -> Union[Error, list["HTTPRequestRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_request_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_request_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/replace_http_request_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/replace_http_request_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPRequestRule]]:
+) -> Union[Error, HTTPRequestRule]:
     if response.status_code == 200:
         response_200 = HTTPRequestRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPRequestRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/replace_http_request_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/replace_http_request_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPRequestRule]]:
+) -> Union[Error, HTTPRequestRule]:
     if response.status_code == 200:
         response_200 = HTTPRequestRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPRequestRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/replace_http_request_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_request_rule/replace_http_request_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_request_rule import HTTPRequestRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPRequestRule]]:
+) -> Union[Error, HTTPRequestRule]:
     if response.status_code == 200:
         response_200 = HTTPRequestRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPRequestRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/create_http_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/create_http_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPResponseRule]]:
+) -> Union[Error, HTTPResponseRule]:
     if response.status_code == 201:
         response_201 = HTTPResponseRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/create_http_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/create_http_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPResponseRule]]:
+) -> Union[Error, HTTPResponseRule]:
     if response.status_code == 201:
         response_201 = HTTPResponseRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/create_http_response_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/create_http_response_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPResponseRule]]:
+) -> Union[Error, HTTPResponseRule]:
     if response.status_code == 201:
         response_201 = HTTPResponseRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = HTTPResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/delete_http_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/delete_http_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/delete_http_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/delete_http_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/delete_http_response_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/delete_http_response_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/get_all_http_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/get_all_http_response_rule_backend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPResponseRule"]]:
+) -> Union[Error, list["HTTPResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_response_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPResponseRule"]]:
+) -> Response[Union[Error, list["HTTPResponseRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPResponseRule"]]:
+) -> Response[Union[Error, list["HTTPResponseRule"]]]:
     """Return an array of all HTTP Response Rules
 
      Returns all HTTP Response Rules that are configured in specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPResponseRule']]
+        Response[Union[Error, list['HTTPResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPResponseRule"]]:
+) -> Optional[Union[Error, list["HTTPResponseRule"]]]:
     """Return an array of all HTTP Response Rules
 
      Returns all HTTP Response Rules that are configured in specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPResponseRule']
+        Union[Error, list['HTTPResponseRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPResponseRule"]]:
+) -> Response[Union[Error, list["HTTPResponseRule"]]]:
     """Return an array of all HTTP Response Rules
 
      Returns all HTTP Response Rules that are configured in specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPResponseRule']]
+        Response[Union[Error, list['HTTPResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPResponseRule"]]:
+) -> Optional[Union[Error, list["HTTPResponseRule"]]]:
     """Return an array of all HTTP Response Rules
 
      Returns all HTTP Response Rules that are configured in specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPResponseRule']
+        Union[Error, list['HTTPResponseRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/get_all_http_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/get_all_http_response_rule_defaults.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPResponseRule"]]:
+) -> Union[Error, list["HTTPResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_response_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPResponseRule"]]:
+) -> Response[Union[Error, list["HTTPResponseRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPResponseRule"]]:
+) -> Response[Union[Error, list["HTTPResponseRule"]]]:
     """Return an array of all HTTP Response Rules
 
      Returns all HTTP Response Rules that are configured in specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPResponseRule']]
+        Response[Union[Error, list['HTTPResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPResponseRule"]]:
+) -> Optional[Union[Error, list["HTTPResponseRule"]]]:
     """Return an array of all HTTP Response Rules
 
      Returns all HTTP Response Rules that are configured in specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPResponseRule']
+        Union[Error, list['HTTPResponseRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPResponseRule"]]:
+) -> Response[Union[Error, list["HTTPResponseRule"]]]:
     """Return an array of all HTTP Response Rules
 
      Returns all HTTP Response Rules that are configured in specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPResponseRule']]
+        Response[Union[Error, list['HTTPResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPResponseRule"]]:
+) -> Optional[Union[Error, list["HTTPResponseRule"]]]:
     """Return an array of all HTTP Response Rules
 
      Returns all HTTP Response Rules that are configured in specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPResponseRule']
+        Union[Error, list['HTTPResponseRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/get_all_http_response_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/get_all_http_response_rule_frontend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HTTPResponseRule"]]:
+) -> Union[Error, list["HTTPResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemashttp_response_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HTTPResponseRule"]]:
+) -> Response[Union[Error, list["HTTPResponseRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPResponseRule"]]:
+) -> Response[Union[Error, list["HTTPResponseRule"]]]:
     """Return an array of all HTTP Response Rules
 
      Returns all HTTP Response Rules that are configured in specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPResponseRule']]
+        Response[Union[Error, list['HTTPResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPResponseRule"]]:
+) -> Optional[Union[Error, list["HTTPResponseRule"]]]:
     """Return an array of all HTTP Response Rules
 
      Returns all HTTP Response Rules that are configured in specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPResponseRule']
+        Union[Error, list['HTTPResponseRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["HTTPResponseRule"]]:
+) -> Response[Union[Error, list["HTTPResponseRule"]]]:
     """Return an array of all HTTP Response Rules
 
      Returns all HTTP Response Rules that are configured in specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HTTPResponseRule']]
+        Response[Union[Error, list['HTTPResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["HTTPResponseRule"]]:
+) -> Optional[Union[Error, list["HTTPResponseRule"]]]:
     """Return an array of all HTTP Response Rules
 
      Returns all HTTP Response Rules that are configured in specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HTTPResponseRule']
+        Union[Error, list['HTTPResponseRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/get_http_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/get_http_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPResponseRule]]:
+) -> Union[Error, HTTPResponseRule]:
     if response.status_code == 200:
         response_200 = HTTPResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/get_http_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/get_http_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPResponseRule]]:
+) -> Union[Error, HTTPResponseRule]:
     if response.status_code == 200:
         response_200 = HTTPResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/get_http_response_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/get_http_response_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPResponseRule]]:
+) -> Union[Error, HTTPResponseRule]:
     if response.status_code == 200:
         response_200 = HTTPResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/replace_all_http_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/replace_all_http_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_response_rules_item_data in body:
         componentsschemashttp_response_rules_item = componentsschemashttp_response_rules_item_data.to_dict()
-        _body.append(componentsschemashttp_response_rules_item)
+        _kwargs["json"].append(componentsschemashttp_response_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPResponseRule"]]]:
+) -> Union[Error, list["HTTPResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_response_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_response_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/replace_all_http_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/replace_all_http_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_response_rules_item_data in body:
         componentsschemashttp_response_rules_item = componentsschemashttp_response_rules_item_data.to_dict()
-        _body.append(componentsschemashttp_response_rules_item)
+        _kwargs["json"].append(componentsschemashttp_response_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPResponseRule"]]]:
+) -> Union[Error, list["HTTPResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_response_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_response_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/replace_all_http_response_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/replace_all_http_response_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemashttp_response_rules_item_data in body:
         componentsschemashttp_response_rules_item = componentsschemashttp_response_rules_item_data.to_dict()
-        _body.append(componentsschemashttp_response_rules_item)
+        _kwargs["json"].append(componentsschemashttp_response_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["HTTPResponseRule"]]]:
+) -> Union[Error, list["HTTPResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemashttp_response_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemashttp_response_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/replace_http_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/replace_http_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPResponseRule]]:
+) -> Union[Error, HTTPResponseRule]:
     if response.status_code == 200:
         response_200 = HTTPResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/replace_http_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/replace_http_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPResponseRule]]:
+) -> Union[Error, HTTPResponseRule]:
     if response.status_code == 200:
         response_200 = HTTPResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/replace_http_response_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/http_response_rule/replace_http_response_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.http_response_rule import HTTPResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HTTPResponseRule]]:
+) -> Union[Error, HTTPResponseRule]:
     if response.status_code == 200:
         response_200 = HTTPResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = HTTPResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/information/get_haproxy_process_info.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/information/get_haproxy_process_info.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.ha_proxy_information import HAProxyInformation
 from ...types import Response
 
@@ -20,20 +20,20 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[HAProxyInformation]:
+) -> Union[Error, HAProxyInformation]:
     if response.status_code == 200:
         response_200 = HAProxyInformation.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[HAProxyInformation]:
+) -> Response[Union[Error, HAProxyInformation]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -45,7 +45,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[HAProxyInformation]:
+) -> Response[Union[Error, HAProxyInformation]]:
     """Return HAProxy process information
 
      Return HAProxy process information
@@ -55,7 +55,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HAProxyInformation]
+        Response[Union[Error, HAProxyInformation]]
     """
 
     kwargs = _get_kwargs()
@@ -70,7 +70,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[HAProxyInformation]:
+) -> Optional[Union[Error, HAProxyInformation]]:
     """Return HAProxy process information
 
      Return HAProxy process information
@@ -80,7 +80,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HAProxyInformation
+        Union[Error, HAProxyInformation]
     """
 
     return sync_detailed(
@@ -91,7 +91,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[HAProxyInformation]:
+) -> Response[Union[Error, HAProxyInformation]]:
     """Return HAProxy process information
 
      Return HAProxy process information
@@ -101,7 +101,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HAProxyInformation]
+        Response[Union[Error, HAProxyInformation]]
     """
 
     kwargs = _get_kwargs()
@@ -114,7 +114,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[HAProxyInformation]:
+) -> Optional[Union[Error, HAProxyInformation]]:
     """Return HAProxy process information
 
      Return HAProxy process information
@@ -124,7 +124,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HAProxyInformation
+        Union[Error, HAProxyInformation]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/information/get_info.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/information/get_info.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.information import Information
 from ...types import Response
 
@@ -18,18 +18,22 @@ def _get_kwargs() -> dict[str, Any]:
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Information]:
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Union[Error, Information]:
     if response.status_code == 200:
         response_200 = Information.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Information]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, Information]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -41,7 +45,7 @@ def _build_response(*, client: Union[AuthenticatedClient, Client], response: htt
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[Information]:
+) -> Response[Union[Error, Information]]:
     """Return API, hardware and OS information
 
      Return API, hardware and OS information
@@ -51,7 +55,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Information]
+        Response[Union[Error, Information]]
     """
 
     kwargs = _get_kwargs()
@@ -66,7 +70,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[Information]:
+) -> Optional[Union[Error, Information]]:
     """Return API, hardware and OS information
 
      Return API, hardware and OS information
@@ -76,7 +80,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Information
+        Union[Error, Information]
     """
 
     return sync_detailed(
@@ -87,7 +91,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[Information]:
+) -> Response[Union[Error, Information]]:
     """Return API, hardware and OS information
 
      Return API, hardware and OS information
@@ -97,7 +101,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Information]
+        Response[Union[Error, Information]]
     """
 
     kwargs = _get_kwargs()
@@ -110,7 +114,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[Information]:
+) -> Optional[Union[Error, Information]]:
     """Return API, hardware and OS information
 
      Return API, hardware and OS information
@@ -120,7 +124,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Information
+        Union[Error, Information]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_forward/create_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_forward/create_log_forward.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_forward import LogForward
@@ -38,9 +37,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -49,27 +47,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogForward]]:
+) -> Union[Error, LogForward]:
     if response.status_code == 201:
         response_201 = LogForward.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = LogForward.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_forward/delete_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_forward/delete_log_forward.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_forward/get_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_forward/get_log_forward.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_forward import LogForward
@@ -35,19 +34,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogForward]]:
+) -> Union[Error, LogForward]:
     if response.status_code == 200:
         response_200 = LogForward.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_forward/get_log_forwards.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_forward/get_log_forwards.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.log_forward import LogForward
 from ...types import UNSET, Response, Unset
 
@@ -33,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["LogForward"]]:
+) -> Union[Error, list["LogForward"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemaslog_forwards_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["LogForward"]]:
+) -> Response[Union[Error, list["LogForward"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["LogForward"]]:
+) -> Response[Union[Error, list["LogForward"]]]:
     """Return an array of log forwards
 
      Returns an array of all configured log forwards.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogForward']]
+        Response[Union[Error, list['LogForward']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["LogForward"]]:
+) -> Optional[Union[Error, list["LogForward"]]]:
     """Return an array of log forwards
 
      Returns an array of all configured log forwards.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogForward']
+        Union[Error, list['LogForward']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["LogForward"]]:
+) -> Response[Union[Error, list["LogForward"]]]:
     """Return an array of log forwards
 
      Returns an array of all configured log forwards.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogForward']]
+        Response[Union[Error, list['LogForward']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["LogForward"]]:
+) -> Optional[Union[Error, list["LogForward"]]]:
     """Return an array of log forwards
 
      Returns an array of all configured log forwards.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogForward']
+        Union[Error, list['LogForward']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_forward/replace_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_forward/replace_log_forward.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_forward import LogForward
@@ -39,9 +38,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,27 +48,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogForward]]:
+) -> Union[Error, LogForward]:
     if response.status_code == 200:
         response_200 = LogForward.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = LogForward.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_profile/create_log_profile.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_profile/create_log_profile.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_profile import LogProfile
@@ -35,9 +34,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -46,27 +44,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogProfile]]:
+) -> Union[Error, LogProfile]:
     if response.status_code == 201:
         response_201 = LogProfile.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = LogProfile.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_profile/delete_log_profile.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_profile/delete_log_profile.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_profile/edit_log_profile.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_profile/edit_log_profile.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_profile import LogProfile
@@ -36,9 +35,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -47,27 +45,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogProfile]]:
+) -> Union[Error, LogProfile]:
     if response.status_code == 200:
         response_200 = LogProfile.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = LogProfile.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_profile/get_log_profile.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_profile/get_log_profile.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_profile import LogProfile
@@ -32,19 +31,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogProfile]]:
+) -> Union[Error, LogProfile]:
     if response.status_code == 200:
         response_200 = LogProfile.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_profile/get_log_profiles.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_profile/get_log_profiles.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.log_profile import LogProfile
 from ...types import UNSET, Response, Unset
 
@@ -30,7 +30,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["LogProfile"]]:
+) -> Union[Error, list["LogProfile"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -40,15 +40,15 @@ def _parse_response(
             response_200.append(componentsschemaslog_profiles_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["LogProfile"]]:
+) -> Response[Union[Error, list["LogProfile"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -61,7 +61,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogProfile"]]:
+) -> Response[Union[Error, list["LogProfile"]]]:
     """Return all the Log Profiles
 
      Returns an array of all the configured log_profile sections in HAProxy
@@ -74,7 +74,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogProfile']]
+        Response[Union[Error, list['LogProfile']]]
     """
 
     kwargs = _get_kwargs(
@@ -92,7 +92,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogProfile"]]:
+) -> Optional[Union[Error, list["LogProfile"]]]:
     """Return all the Log Profiles
 
      Returns an array of all the configured log_profile sections in HAProxy
@@ -105,7 +105,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogProfile']
+        Union[Error, list['LogProfile']]
     """
 
     return sync_detailed(
@@ -118,7 +118,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogProfile"]]:
+) -> Response[Union[Error, list["LogProfile"]]]:
     """Return all the Log Profiles
 
      Returns an array of all the configured log_profile sections in HAProxy
@@ -131,7 +131,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogProfile']]
+        Response[Union[Error, list['LogProfile']]]
     """
 
     kwargs = _get_kwargs(
@@ -147,7 +147,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogProfile"]]:
+) -> Optional[Union[Error, list["LogProfile"]]]:
     """Return all the Log Profiles
 
      Returns an array of all the configured log_profile sections in HAProxy
@@ -160,7 +160,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogProfile']
+        Union[Error, list['LogProfile']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/create_log_target_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/create_log_target_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 201:
         response_201 = LogTarget.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = LogTarget.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/create_log_target_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/create_log_target_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 201:
         response_201 = LogTarget.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = LogTarget.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/create_log_target_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/create_log_target_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 201:
         response_201 = LogTarget.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = LogTarget.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/create_log_target_global.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/create_log_target_global.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -36,38 +35,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 201:
         response_201 = LogTarget.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = LogTarget.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/create_log_target_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/create_log_target_log_forward.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 201:
         response_201 = LogTarget.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = LogTarget.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/create_log_target_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/create_log_target_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 201:
         response_201 = LogTarget.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = LogTarget.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/delete_log_target_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/delete_log_target_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/delete_log_target_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/delete_log_target_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/delete_log_target_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/delete_log_target_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/delete_log_target_global.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/delete_log_target_global.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/delete_log_target_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/delete_log_target_log_forward.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/delete_log_target_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/delete_log_target_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_all_log_target_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_all_log_target_backend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.log_target import LogTarget
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["LogTarget"]]:
+) -> Union[Error, list["LogTarget"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemaslog_targets_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogTarget']]
+        Response[Union[Error, list['LogTarget']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogTarget"]]:
+) -> Optional[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogTarget']
+        Union[Error, list['LogTarget']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogTarget']]
+        Response[Union[Error, list['LogTarget']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogTarget"]]:
+) -> Optional[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogTarget']
+        Union[Error, list['LogTarget']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_all_log_target_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_all_log_target_defaults.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.log_target import LogTarget
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["LogTarget"]]:
+) -> Union[Error, list["LogTarget"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemaslog_targets_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogTarget']]
+        Response[Union[Error, list['LogTarget']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogTarget"]]:
+) -> Optional[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogTarget']
+        Union[Error, list['LogTarget']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogTarget']]
+        Response[Union[Error, list['LogTarget']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogTarget"]]:
+) -> Optional[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogTarget']
+        Union[Error, list['LogTarget']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_all_log_target_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_all_log_target_frontend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.log_target import LogTarget
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["LogTarget"]]:
+) -> Union[Error, list["LogTarget"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemaslog_targets_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogTarget']]
+        Response[Union[Error, list['LogTarget']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogTarget"]]:
+) -> Optional[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogTarget']
+        Union[Error, list['LogTarget']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogTarget']]
+        Response[Union[Error, list['LogTarget']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogTarget"]]:
+) -> Optional[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogTarget']
+        Union[Error, list['LogTarget']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_all_log_target_global.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_all_log_target_global.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.log_target import LogTarget
 from ...types import UNSET, Response, Unset
 
@@ -30,7 +30,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["LogTarget"]]:
+) -> Union[Error, list["LogTarget"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -40,15 +40,15 @@ def _parse_response(
             response_200.append(componentsschemaslog_targets_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -61,7 +61,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -74,7 +74,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogTarget']]
+        Response[Union[Error, list['LogTarget']]]
     """
 
     kwargs = _get_kwargs(
@@ -92,7 +92,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogTarget"]]:
+) -> Optional[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -105,7 +105,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogTarget']
+        Union[Error, list['LogTarget']]
     """
 
     return sync_detailed(
@@ -118,7 +118,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -131,7 +131,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogTarget']]
+        Response[Union[Error, list['LogTarget']]]
     """
 
     kwargs = _get_kwargs(
@@ -147,7 +147,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogTarget"]]:
+) -> Optional[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -160,7 +160,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogTarget']
+        Union[Error, list['LogTarget']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_all_log_target_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_all_log_target_log_forward.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.log_target import LogTarget
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["LogTarget"]]:
+) -> Union[Error, list["LogTarget"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemaslog_targets_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogTarget']]
+        Response[Union[Error, list['LogTarget']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogTarget"]]:
+) -> Optional[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogTarget']
+        Union[Error, list['LogTarget']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogTarget']]
+        Response[Union[Error, list['LogTarget']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogTarget"]]:
+) -> Optional[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogTarget']
+        Union[Error, list['LogTarget']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_all_log_target_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_all_log_target_peer.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.log_target import LogTarget
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["LogTarget"]]:
+) -> Union[Error, list["LogTarget"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemaslog_targets_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogTarget']]
+        Response[Union[Error, list['LogTarget']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogTarget"]]:
+) -> Optional[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogTarget']
+        Union[Error, list['LogTarget']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["LogTarget"]]:
+) -> Response[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['LogTarget']]
+        Response[Union[Error, list['LogTarget']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["LogTarget"]]:
+) -> Optional[Union[Error, list["LogTarget"]]]:
     """Return an array of all Log Targets
 
      Returns all Log Targets that are configured in specified parent.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['LogTarget']
+        Union[Error, list['LogTarget']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_log_target_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_log_target_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 200:
         response_200 = LogTarget.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_log_target_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_log_target_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 200:
         response_200 = LogTarget.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_log_target_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_log_target_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 200:
         response_200 = LogTarget.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_log_target_global.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_log_target_global.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -30,21 +29,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 200:
         response_200 = LogTarget.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_log_target_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_log_target_log_forward.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 200:
         response_200 = LogTarget.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_log_target_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/get_log_target_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 200:
         response_200 = LogTarget.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_all_log_target_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_all_log_target_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemaslog_targets_item_data in body:
         componentsschemaslog_targets_item = componentsschemaslog_targets_item_data.to_dict()
-        _body.append(componentsschemaslog_targets_item)
+        _kwargs["json"].append(componentsschemaslog_targets_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["LogTarget"]]]:
+) -> Union[Error, list["LogTarget"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemaslog_targets_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemaslog_targets_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_all_log_target_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_all_log_target_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemaslog_targets_item_data in body:
         componentsschemaslog_targets_item = componentsschemaslog_targets_item_data.to_dict()
-        _body.append(componentsschemaslog_targets_item)
+        _kwargs["json"].append(componentsschemaslog_targets_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["LogTarget"]]]:
+) -> Union[Error, list["LogTarget"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemaslog_targets_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemaslog_targets_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_all_log_target_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_all_log_target_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemaslog_targets_item_data in body:
         componentsschemaslog_targets_item = componentsschemaslog_targets_item_data.to_dict()
-        _body.append(componentsschemaslog_targets_item)
+        _kwargs["json"].append(componentsschemaslog_targets_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["LogTarget"]]]:
+) -> Union[Error, list["LogTarget"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemaslog_targets_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemaslog_targets_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_all_log_target_global.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_all_log_target_global.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -35,12 +34,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemaslog_targets_item_data in body:
         componentsschemaslog_targets_item = componentsschemaslog_targets_item_data.to_dict()
-        _body.append(componentsschemaslog_targets_item)
+        _kwargs["json"].append(componentsschemaslog_targets_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -49,7 +47,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["LogTarget"]]]:
+) -> Union[Error, list["LogTarget"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -59,6 +57,7 @@ def _parse_response(
             response_200.append(componentsschemaslog_targets_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -68,14 +67,15 @@ def _parse_response(
             response_202.append(componentsschemaslog_targets_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_all_log_target_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_all_log_target_log_forward.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemaslog_targets_item_data in body:
         componentsschemaslog_targets_item = componentsschemaslog_targets_item_data.to_dict()
-        _body.append(componentsschemaslog_targets_item)
+        _kwargs["json"].append(componentsschemaslog_targets_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["LogTarget"]]]:
+) -> Union[Error, list["LogTarget"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemaslog_targets_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemaslog_targets_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_all_log_target_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_all_log_target_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemaslog_targets_item_data in body:
         componentsschemaslog_targets_item = componentsschemaslog_targets_item_data.to_dict()
-        _body.append(componentsschemaslog_targets_item)
+        _kwargs["json"].append(componentsschemaslog_targets_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["LogTarget"]]]:
+) -> Union[Error, list["LogTarget"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemaslog_targets_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemaslog_targets_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_log_target_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_log_target_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 200:
         response_200 = LogTarget.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = LogTarget.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_log_target_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_log_target_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 200:
         response_200 = LogTarget.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = LogTarget.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_log_target_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_log_target_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 200:
         response_200 = LogTarget.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = LogTarget.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_log_target_global.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_log_target_global.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -36,38 +35,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 200:
         response_200 = LogTarget.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = LogTarget.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_log_target_log_forward.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_log_target_log_forward.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 200:
         response_200 = LogTarget.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = LogTarget.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_log_target_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/log_target/replace_log_target_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.log_target import LogTarget
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, LogTarget]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, LogTarget]:
     if response.status_code == 200:
         response_200 = LogTarget.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = LogTarget.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailer_entry/create_mailer_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailer_entry/create_mailer_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.mailer_entry import MailerEntry
@@ -38,9 +37,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -49,27 +47,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, MailerEntry]]:
+) -> Union[Error, MailerEntry]:
     if response.status_code == 201:
         response_201 = MailerEntry.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = MailerEntry.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailer_entry/delete_mailer_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailer_entry/delete_mailer_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -38,23 +37,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailer_entry/get_mailer_entries.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailer_entry/get_mailer_entries.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.mailer_entry import MailerEntry
 from ...types import UNSET, Response, Unset
 
@@ -33,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["MailerEntry"]]:
+) -> Union[Error, list["MailerEntry"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasmailer_entries_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["MailerEntry"]]:
+) -> Response[Union[Error, list["MailerEntry"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     mailers_section: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["MailerEntry"]]:
+) -> Response[Union[Error, list["MailerEntry"]]]:
     """Return an array of mailer_entries
 
      Returns an array of all the mailer_entries configured in the specified mailers section.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['MailerEntry']]
+        Response[Union[Error, list['MailerEntry']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     mailers_section: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["MailerEntry"]]:
+) -> Optional[Union[Error, list["MailerEntry"]]]:
     """Return an array of mailer_entries
 
      Returns an array of all the mailer_entries configured in the specified mailers section.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['MailerEntry']
+        Union[Error, list['MailerEntry']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     mailers_section: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["MailerEntry"]]:
+) -> Response[Union[Error, list["MailerEntry"]]]:
     """Return an array of mailer_entries
 
      Returns an array of all the mailer_entries configured in the specified mailers section.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['MailerEntry']]
+        Response[Union[Error, list['MailerEntry']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     mailers_section: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["MailerEntry"]]:
+) -> Optional[Union[Error, list["MailerEntry"]]]:
     """Return an array of mailer_entries
 
      Returns an array of all the mailer_entries configured in the specified mailers section.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['MailerEntry']
+        Union[Error, list['MailerEntry']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailer_entry/get_mailer_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailer_entry/get_mailer_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.mailer_entry import MailerEntry
@@ -35,19 +34,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, MailerEntry]]:
+) -> Union[Error, MailerEntry]:
     if response.status_code == 200:
         response_200 = MailerEntry.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailer_entry/replace_mailer_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailer_entry/replace_mailer_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.mailer_entry import MailerEntry
@@ -39,9 +38,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,27 +48,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, MailerEntry]]:
+) -> Union[Error, MailerEntry]:
     if response.status_code == 200:
         response_200 = MailerEntry.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = MailerEntry.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailers/create_mailers_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailers/create_mailers_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.mailers_section import MailersSection
@@ -38,9 +37,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -49,27 +47,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, MailersSection]]:
+) -> Union[Error, MailersSection]:
     if response.status_code == 201:
         response_201 = MailersSection.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = MailersSection.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailers/delete_mailers_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailers/delete_mailers_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailers/edit_mailers_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailers/edit_mailers_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.mailers_section import MailersSection
@@ -39,9 +38,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,27 +48,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, MailersSection]]:
+) -> Union[Error, MailersSection]:
     if response.status_code == 200:
         response_200 = MailersSection.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = MailersSection.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailers/get_mailers_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailers/get_mailers_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.mailers_section import MailersSection
@@ -35,19 +34,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, MailersSection]]:
+) -> Union[Error, MailersSection]:
     if response.status_code == 200:
         response_200 = MailersSection.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailers/get_mailers_sections.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/mailers/get_mailers_sections.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.mailers_section import MailersSection
 from ...types import UNSET, Response, Unset
 
@@ -33,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["MailersSection"]]:
+) -> Union[Error, list["MailersSection"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -45,15 +45,15 @@ def _parse_response(
             response_200.append(componentsschemasmailers_sections_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["MailersSection"]]:
+) -> Response[Union[Error, list["MailersSection"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -67,7 +67,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["MailersSection"]]:
+) -> Response[Union[Error, list["MailersSection"]]]:
     """Return an array of mailers sections
 
      Returns an array of all the configured mailers in HAProxy
@@ -81,7 +81,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['MailersSection']]
+        Response[Union[Error, list['MailersSection']]]
     """
 
     kwargs = _get_kwargs(
@@ -101,7 +101,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["MailersSection"]]:
+) -> Optional[Union[Error, list["MailersSection"]]]:
     """Return an array of mailers sections
 
      Returns an array of all the configured mailers in HAProxy
@@ -115,7 +115,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['MailersSection']
+        Union[Error, list['MailersSection']]
     """
 
     return sync_detailed(
@@ -130,7 +130,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["MailersSection"]]:
+) -> Response[Union[Error, list["MailersSection"]]]:
     """Return an array of mailers sections
 
      Returns an array of all the configured mailers in HAProxy
@@ -144,7 +144,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['MailersSection']]
+        Response[Union[Error, list['MailersSection']]]
     """
 
     kwargs = _get_kwargs(
@@ -162,7 +162,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["MailersSection"]]:
+) -> Optional[Union[Error, list["MailersSection"]]]:
     """Return an array of mailers sections
 
      Returns an array of all the configured mailers in HAProxy
@@ -176,7 +176,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['MailersSection']
+        Union[Error, list['MailersSection']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/add_map_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/add_map_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.one_map_entry import OneMapEntry
@@ -30,9 +29,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -41,23 +39,25 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, OneMapEntry]]:
+) -> Union[Error, OneMapEntry]:
     if response.status_code == 201:
         response_201 = OneMapEntry.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/add_payload_runtime_map.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/add_payload_runtime_map.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.one_map_entry import OneMapEntry
@@ -30,12 +29,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemasmap_entries_item_data in body:
         componentsschemasmap_entries_item = componentsschemasmap_entries_item_data.to_dict()
-        _body.append(componentsschemasmap_entries_item)
+        _kwargs["json"].append(componentsschemasmap_entries_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -44,7 +42,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["OneMapEntry"]]]:
+) -> Union[Error, list["OneMapEntry"]]:
     if response.status_code == 201:
         response_201 = []
         _response_201 = response.json()
@@ -54,14 +52,15 @@ def _parse_response(
             response_201.append(componentsschemasmap_entries_item)
 
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/clear_runtime_map.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/clear_runtime_map.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -32,20 +31,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/delete_runtime_map_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/delete_runtime_map_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -30,20 +29,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/get_all_runtime_map_files.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/get_all_runtime_map_files.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.map_file import MapFile
@@ -31,7 +30,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["MapFile"]]]:
+) -> Union[Error, list["MapFile"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,14 +40,15 @@ def _parse_response(
             response_200.append(componentsschemasmaps_item)
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/get_one_runtime_map.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/get_one_runtime_map.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.map_file import MapFile
@@ -21,21 +20,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, MapFile]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, MapFile]:
     if response.status_code == 200:
         response_200 = MapFile.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/get_runtime_map_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/get_runtime_map_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.one_map_entry import OneMapEntry
@@ -24,19 +23,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, OneMapEntry]]:
+) -> Union[Error, OneMapEntry]:
     if response.status_code == 200:
         response_200 = OneMapEntry.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/replace_runtime_map_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/replace_runtime_map_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.one_map_entry import OneMapEntry
@@ -32,9 +31,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -43,23 +41,25 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, OneMapEntry]]:
+) -> Union[Error, OneMapEntry]:
     if response.status_code == 200:
         response_200 = OneMapEntry.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/show_runtime_map.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/maps/show_runtime_map.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.one_map_entry import OneMapEntry
@@ -23,7 +22,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["OneMapEntry"]]]:
+) -> Union[Error, list["OneMapEntry"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -33,14 +32,15 @@ def _parse_response(
             response_200.append(componentsschemasmap_entries_item)
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/nameserver/create_nameserver.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/nameserver/create_nameserver.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.nameserver import Nameserver
@@ -38,9 +37,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -49,27 +47,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Nameserver]]:
+) -> Union[Error, Nameserver]:
     if response.status_code == 201:
         response_201 = Nameserver.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Nameserver.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/nameserver/delete_nameserver.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/nameserver/delete_nameserver.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -38,23 +37,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/nameserver/get_nameserver.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/nameserver/get_nameserver.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.nameserver import Nameserver
@@ -35,19 +34,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Nameserver]]:
+) -> Union[Error, Nameserver]:
     if response.status_code == 200:
         response_200 = Nameserver.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/nameserver/get_nameservers.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/nameserver/get_nameservers.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.nameserver import Nameserver
 from ...types import UNSET, Response, Unset
 
@@ -33,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Nameserver"]]:
+) -> Union[Error, list["Nameserver"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasnameservers_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Nameserver"]]:
+) -> Response[Union[Error, list["Nameserver"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     resolver: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Nameserver"]]:
+) -> Response[Union[Error, list["Nameserver"]]]:
     """Return an array of nameservers
 
      Returns an array of all configured nameservers.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Nameserver']]
+        Response[Union[Error, list['Nameserver']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     resolver: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Nameserver"]]:
+) -> Optional[Union[Error, list["Nameserver"]]]:
     """Return an array of nameservers
 
      Returns an array of all configured nameservers.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Nameserver']
+        Union[Error, list['Nameserver']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     resolver: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Nameserver"]]:
+) -> Response[Union[Error, list["Nameserver"]]]:
     """Return an array of nameservers
 
      Returns an array of all configured nameservers.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Nameserver']]
+        Response[Union[Error, list['Nameserver']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     resolver: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Nameserver"]]:
+) -> Optional[Union[Error, list["Nameserver"]]]:
     """Return an array of nameservers
 
      Returns an array of all configured nameservers.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Nameserver']
+        Union[Error, list['Nameserver']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/nameserver/replace_nameserver.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/nameserver/replace_nameserver.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.nameserver import Nameserver
@@ -39,9 +38,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,27 +48,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Nameserver]]:
+) -> Union[Error, Nameserver]:
     if response.status_code == 200:
         response_200 = Nameserver.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Nameserver.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer/create_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer/create_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.peer_section import PeerSection
@@ -38,9 +37,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -49,27 +47,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, PeerSection]]:
+) -> Union[Error, PeerSection]:
     if response.status_code == 201:
         response_201 = PeerSection.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = PeerSection.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer/delete_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer/delete_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer/get_peer_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer/get_peer_section.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.peer_section import PeerSection
@@ -35,19 +34,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, PeerSection]]:
+) -> Union[Error, PeerSection]:
     if response.status_code == 200:
         response_200 = PeerSection.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer/get_peer_sections.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer/get_peer_sections.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.peer_section import PeerSection
 from ...types import UNSET, Response, Unset
 
@@ -33,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["PeerSection"]]:
+) -> Union[Error, list["PeerSection"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemaspeer_sections_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["PeerSection"]]:
+) -> Response[Union[Error, list["PeerSection"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["PeerSection"]]:
+) -> Response[Union[Error, list["PeerSection"]]]:
     """Return an array of peer_section
 
      Returns an array of all configured peer_section.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['PeerSection']]
+        Response[Union[Error, list['PeerSection']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["PeerSection"]]:
+) -> Optional[Union[Error, list["PeerSection"]]]:
     """Return an array of peer_section
 
      Returns an array of all configured peer_section.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['PeerSection']
+        Union[Error, list['PeerSection']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["PeerSection"]]:
+) -> Response[Union[Error, list["PeerSection"]]]:
     """Return an array of peer_section
 
      Returns an array of all configured peer_section.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['PeerSection']]
+        Response[Union[Error, list['PeerSection']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["PeerSection"]]:
+) -> Optional[Union[Error, list["PeerSection"]]]:
     """Return an array of peer_section
 
      Returns an array of all configured peer_section.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['PeerSection']
+        Union[Error, list['PeerSection']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer_entry/create_peer_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer_entry/create_peer_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.peer_entry import PeerEntry
@@ -38,38 +37,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, PeerEntry]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, PeerEntry]:
     if response.status_code == 201:
         response_201 = PeerEntry.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = PeerEntry.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer_entry/delete_peer_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer_entry/delete_peer_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -38,23 +37,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer_entry/get_peer_entries.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer_entry/get_peer_entries.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.peer_entry import PeerEntry
 from ...types import UNSET, Response, Unset
 
@@ -33,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["PeerEntry"]]:
+) -> Union[Error, list["PeerEntry"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemaspeer_entries_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["PeerEntry"]]:
+) -> Response[Union[Error, list["PeerEntry"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     peer_section: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["PeerEntry"]]:
+) -> Response[Union[Error, list["PeerEntry"]]]:
     """Return an array of peer_entries
 
      Returns an array of all peer_entries that are configured in specified peer section.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['PeerEntry']]
+        Response[Union[Error, list['PeerEntry']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     peer_section: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["PeerEntry"]]:
+) -> Optional[Union[Error, list["PeerEntry"]]]:
     """Return an array of peer_entries
 
      Returns an array of all peer_entries that are configured in specified peer section.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['PeerEntry']
+        Union[Error, list['PeerEntry']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     peer_section: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["PeerEntry"]]:
+) -> Response[Union[Error, list["PeerEntry"]]]:
     """Return an array of peer_entries
 
      Returns an array of all peer_entries that are configured in specified peer section.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['PeerEntry']]
+        Response[Union[Error, list['PeerEntry']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     peer_section: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["PeerEntry"]]:
+) -> Optional[Union[Error, list["PeerEntry"]]]:
     """Return an array of peer_entries
 
      Returns an array of all peer_entries that are configured in specified peer section.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['PeerEntry']
+        Union[Error, list['PeerEntry']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer_entry/get_peer_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer_entry/get_peer_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.peer_entry import PeerEntry
@@ -33,21 +32,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, PeerEntry]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, PeerEntry]:
     if response.status_code == 200:
         response_200 = PeerEntry.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer_entry/replace_peer_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/peer_entry/replace_peer_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.peer_entry import PeerEntry
@@ -39,38 +38,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, PeerEntry]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, PeerEntry]:
     if response.status_code == 200:
         response_200 = PeerEntry.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = PeerEntry.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/process_manager/create_program.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/process_manager/create_program.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.program import Program
@@ -35,38 +34,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Program]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Program]:
     if response.status_code == 201:
         response_201 = Program.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Program.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/process_manager/delete_program.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/process_manager/delete_program.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/process_manager/get_program.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/process_manager/get_program.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.program import Program
@@ -30,21 +29,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Program]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Program]:
     if response.status_code == 200:
         response_200 = Program.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/process_manager/get_programs.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/process_manager/get_programs.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.program import Program
 from ...types import UNSET, Response, Unset
 
@@ -30,7 +30,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Program"]]:
+) -> Union[Error, list["Program"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -40,15 +40,15 @@ def _parse_response(
             response_200.append(componentsschemasprograms_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Program"]]:
+) -> Response[Union[Error, list["Program"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -61,7 +61,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Program"]]:
+) -> Response[Union[Error, list["Program"]]]:
     """Return an array of programs
 
      Returns an array of all configured programs in the process-manager configuration file.
@@ -74,7 +74,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Program']]
+        Response[Union[Error, list['Program']]]
     """
 
     kwargs = _get_kwargs(
@@ -92,7 +92,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Program"]]:
+) -> Optional[Union[Error, list["Program"]]]:
     """Return an array of programs
 
      Returns an array of all configured programs in the process-manager configuration file.
@@ -105,7 +105,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Program']
+        Union[Error, list['Program']]
     """
 
     return sync_detailed(
@@ -118,7 +118,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Program"]]:
+) -> Response[Union[Error, list["Program"]]]:
     """Return an array of programs
 
      Returns an array of all configured programs in the process-manager configuration file.
@@ -131,7 +131,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Program']]
+        Response[Union[Error, list['Program']]]
     """
 
     kwargs = _get_kwargs(
@@ -147,7 +147,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Program"]]:
+) -> Optional[Union[Error, list["Program"]]]:
     """Return an array of programs
 
      Returns an array of all configured programs in the process-manager configuration file.
@@ -160,7 +160,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Program']
+        Union[Error, list['Program']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/process_manager/replace_program.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/process_manager/replace_program.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.program import Program
@@ -36,38 +35,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Program]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Program]:
     if response.status_code == 200:
         response_200 = Program.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Program.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/create_quic_initial_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/create_quic_initial_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.quic_initial import QUICInitial
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, QUICInitial]]:
+) -> Union[Error, QUICInitial]:
     if response.status_code == 201:
         response_201 = QUICInitial.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = QUICInitial.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/create_quic_initial_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/create_quic_initial_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.quic_initial import QUICInitial
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, QUICInitial]]:
+) -> Union[Error, QUICInitial]:
     if response.status_code == 201:
         response_201 = QUICInitial.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = QUICInitial.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/delete_quic_initial_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/delete_quic_initial_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/delete_quic_initial_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/delete_quic_initial_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/get_all_quic_initial_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/get_all_quic_initial_rule_defaults.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.quic_initial import QUICInitial
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["QUICInitial"]]:
+) -> Union[Error, list["QUICInitial"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasquic_initial_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["QUICInitial"]]:
+) -> Response[Union[Error, list["QUICInitial"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["QUICInitial"]]:
+) -> Response[Union[Error, list["QUICInitial"]]]:
     """Return an array of all QUIC Initial rules
 
      Returns all QUIC Initial rules that are configured in specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['QUICInitial']]
+        Response[Union[Error, list['QUICInitial']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["QUICInitial"]]:
+) -> Optional[Union[Error, list["QUICInitial"]]]:
     """Return an array of all QUIC Initial rules
 
      Returns all QUIC Initial rules that are configured in specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['QUICInitial']
+        Union[Error, list['QUICInitial']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["QUICInitial"]]:
+) -> Response[Union[Error, list["QUICInitial"]]]:
     """Return an array of all QUIC Initial rules
 
      Returns all QUIC Initial rules that are configured in specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['QUICInitial']]
+        Response[Union[Error, list['QUICInitial']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["QUICInitial"]]:
+) -> Optional[Union[Error, list["QUICInitial"]]]:
     """Return an array of all QUIC Initial rules
 
      Returns all QUIC Initial rules that are configured in specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['QUICInitial']
+        Union[Error, list['QUICInitial']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/get_all_quic_initial_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/get_all_quic_initial_rule_frontend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.quic_initial import QUICInitial
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["QUICInitial"]]:
+) -> Union[Error, list["QUICInitial"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasquic_initial_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["QUICInitial"]]:
+) -> Response[Union[Error, list["QUICInitial"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["QUICInitial"]]:
+) -> Response[Union[Error, list["QUICInitial"]]]:
     """Return an array of all QUIC Initial rules
 
      Returns all QUIC Initial rules that are configured in specified parent.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['QUICInitial']]
+        Response[Union[Error, list['QUICInitial']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["QUICInitial"]]:
+) -> Optional[Union[Error, list["QUICInitial"]]]:
     """Return an array of all QUIC Initial rules
 
      Returns all QUIC Initial rules that are configured in specified parent.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['QUICInitial']
+        Union[Error, list['QUICInitial']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["QUICInitial"]]:
+) -> Response[Union[Error, list["QUICInitial"]]]:
     """Return an array of all QUIC Initial rules
 
      Returns all QUIC Initial rules that are configured in specified parent.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['QUICInitial']]
+        Response[Union[Error, list['QUICInitial']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["QUICInitial"]]:
+) -> Optional[Union[Error, list["QUICInitial"]]]:
     """Return an array of all QUIC Initial rules
 
      Returns all QUIC Initial rules that are configured in specified parent.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['QUICInitial']
+        Union[Error, list['QUICInitial']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/get_quic_initial_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/get_quic_initial_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.quic_initial import QUICInitial
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, QUICInitial]]:
+) -> Union[Error, QUICInitial]:
     if response.status_code == 200:
         response_200 = QUICInitial.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/get_quic_initial_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/get_quic_initial_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.quic_initial import QUICInitial
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, QUICInitial]]:
+) -> Union[Error, QUICInitial]:
     if response.status_code == 200:
         response_200 = QUICInitial.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/replace_all_quic_initial_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/replace_all_quic_initial_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.quic_initial import QUICInitial
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemasquic_initial_rules_item_data in body:
         componentsschemasquic_initial_rules_item = componentsschemasquic_initial_rules_item_data.to_dict()
-        _body.append(componentsschemasquic_initial_rules_item)
+        _kwargs["json"].append(componentsschemasquic_initial_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["QUICInitial"]]]:
+) -> Union[Error, list["QUICInitial"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemasquic_initial_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemasquic_initial_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/replace_all_quic_initial_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/replace_all_quic_initial_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.quic_initial import QUICInitial
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemasquic_initial_rules_item_data in body:
         componentsschemasquic_initial_rules_item = componentsschemasquic_initial_rules_item_data.to_dict()
-        _body.append(componentsschemasquic_initial_rules_item)
+        _kwargs["json"].append(componentsschemasquic_initial_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["QUICInitial"]]]:
+) -> Union[Error, list["QUICInitial"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemasquic_initial_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemasquic_initial_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/replace_quic_initial_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/replace_quic_initial_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.quic_initial import QUICInitial
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, QUICInitial]]:
+) -> Union[Error, QUICInitial]:
     if response.status_code == 200:
         response_200 = QUICInitial.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = QUICInitial.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/replace_quic_initial_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/quic_initial_rule/replace_quic_initial_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.quic_initial import QUICInitial
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, QUICInitial]]:
+) -> Union[Error, QUICInitial]:
     if response.status_code == 200:
         response_200 = QUICInitial.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = QUICInitial.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/reloads/get_reload.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/reloads/get_reload.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ha_proxy_reload import HAProxyReload
@@ -23,19 +22,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, HAProxyReload]]:
+) -> Union[Error, HAProxyReload]:
     if response.status_code == 200:
         response_200 = HAProxyReload.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/reloads/get_reloads.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/reloads/get_reloads.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.ha_proxy_reload import HAProxyReload
 from ...types import Response
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["HAProxyReload"]]:
+) -> Union[Error, list["HAProxyReload"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasreloads_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["HAProxyReload"]]:
+) -> Response[Union[Error, list["HAProxyReload"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["HAProxyReload"]]:
+) -> Response[Union[Error, list["HAProxyReload"]]]:
     """Return list of HAProxy Reloads.
 
      Returns a list of HAProxy reloads.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HAProxyReload']]
+        Response[Union[Error, list['HAProxyReload']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["HAProxyReload"]]:
+) -> Optional[Union[Error, list["HAProxyReload"]]]:
     """Return list of HAProxy Reloads.
 
      Returns a list of HAProxy reloads.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HAProxyReload']
+        Union[Error, list['HAProxyReload']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["HAProxyReload"]]:
+) -> Response[Union[Error, list["HAProxyReload"]]]:
     """Return list of HAProxy Reloads.
 
      Returns a list of HAProxy reloads.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['HAProxyReload']]
+        Response[Union[Error, list['HAProxyReload']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["HAProxyReload"]]:
+) -> Optional[Union[Error, list["HAProxyReload"]]]:
     """Return list of HAProxy Reloads.
 
      Returns a list of HAProxy reloads.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['HAProxyReload']
+        Union[Error, list['HAProxyReload']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/resolver/create_resolver.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/resolver/create_resolver.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.resolver import Resolver
@@ -38,38 +37,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Resolver]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Resolver]:
     if response.status_code == 201:
         response_201 = Resolver.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Resolver.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/resolver/delete_resolver.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/resolver/delete_resolver.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/resolver/get_resolver.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/resolver/get_resolver.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.resolver import Resolver
@@ -33,21 +32,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Resolver]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Resolver]:
     if response.status_code == 200:
         response_200 = Resolver.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/resolver/get_resolvers.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/resolver/get_resolvers.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.resolver import Resolver
 from ...types import UNSET, Response, Unset
 
@@ -33,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Resolver"]]:
+) -> Union[Error, list["Resolver"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasresolvers_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Resolver"]]:
+) -> Response[Union[Error, list["Resolver"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["Resolver"]]:
+) -> Response[Union[Error, list["Resolver"]]]:
     """Return an array of resolvers
 
      Returns an array of all configured resolvers.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Resolver']]
+        Response[Union[Error, list['Resolver']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["Resolver"]]:
+) -> Optional[Union[Error, list["Resolver"]]]:
     """Return an array of resolvers
 
      Returns an array of all configured resolvers.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Resolver']
+        Union[Error, list['Resolver']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["Resolver"]]:
+) -> Response[Union[Error, list["Resolver"]]]:
     """Return an array of resolvers
 
      Returns an array of all configured resolvers.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Resolver']]
+        Response[Union[Error, list['Resolver']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["Resolver"]]:
+) -> Optional[Union[Error, list["Resolver"]]]:
     """Return an array of resolvers
 
      Returns an array of all configured resolvers.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Resolver']
+        Union[Error, list['Resolver']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/resolver/replace_resolver.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/resolver/replace_resolver.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.resolver import Resolver
@@ -39,38 +38,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Resolver]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Resolver]:
     if response.status_code == 200:
         response_200 = Resolver.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Resolver.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ring/create_ring.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ring/create_ring.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ring import Ring
@@ -38,38 +37,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Ring]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Ring]:
     if response.status_code == 201:
         response_201 = Ring.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Ring.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ring/delete_ring.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ring/delete_ring.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ring/get_ring.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ring/get_ring.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ring import Ring
@@ -33,21 +32,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Ring]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Ring]:
     if response.status_code == 200:
         response_200 = Ring.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ring/get_rings.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ring/get_rings.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.ring import Ring
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[list["Ring"]]:
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Union[Error, list["Ring"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,13 +43,15 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
             response_200.append(componentsschemasrings_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[list["Ring"]]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, list["Ring"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -61,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["Ring"]]:
+) -> Response[Union[Error, list["Ring"]]]:
     """Return an array of rings
 
      Returns an array of all configured rings.
@@ -75,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Ring']]
+        Response[Union[Error, list['Ring']]]
     """
 
     kwargs = _get_kwargs(
@@ -95,7 +99,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["Ring"]]:
+) -> Optional[Union[Error, list["Ring"]]]:
     """Return an array of rings
 
      Returns an array of all configured rings.
@@ -109,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Ring']
+        Union[Error, list['Ring']]
     """
 
     return sync_detailed(
@@ -124,7 +128,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["Ring"]]:
+) -> Response[Union[Error, list["Ring"]]]:
     """Return an array of rings
 
      Returns an array of all configured rings.
@@ -138,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Ring']]
+        Response[Union[Error, list['Ring']]]
     """
 
     kwargs = _get_kwargs(
@@ -156,7 +160,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["Ring"]]:
+) -> Optional[Union[Error, list["Ring"]]]:
     """Return an array of rings
 
      Returns an array of all configured rings.
@@ -170,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Ring']
+        Union[Error, list['Ring']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ring/replace_ring.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ring/replace_ring.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ring import Ring
@@ -39,38 +38,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Ring]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Ring]:
     if response.status_code == 200:
         response_200 = Ring.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Ring.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/add_runtime_server.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/add_runtime_server.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.runtime_add_server import RuntimeAddServer
@@ -22,9 +21,8 @@ def _get_kwargs(
         "url": f"/services/haproxy/runtime/backends/{parent_name}/servers",
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -33,27 +31,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, RuntimeAddServer]]:
+) -> Union[Error, RuntimeAddServer]:
     if response.status_code == 201:
         response_201 = RuntimeAddServer.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/create_server_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/create_server_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server import Server
@@ -36,38 +35,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Server]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Server]:
     if response.status_code == 201:
         response_201 = Server.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Server.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/create_server_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/create_server_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server import Server
@@ -36,38 +35,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Server]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Server]:
     if response.status_code == 201:
         response_201 = Server.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Server.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/create_server_ring.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/create_server_ring.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server import Server
@@ -36,38 +35,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Server]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Server]:
     if response.status_code == 201:
         response_201 = Server.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Server.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/delete_runtime_server.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/delete_runtime_server.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import Response
@@ -21,24 +20,24 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/delete_server_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/delete_server_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/delete_server_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/delete_server_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/delete_server_ring.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/delete_server_ring.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_all_runtime_server.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_all_runtime_server.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.runtime_server import RuntimeServer
 from ...types import Response
 
@@ -22,7 +22,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["RuntimeServer"]]:
+) -> Union[Error, list["RuntimeServer"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -32,15 +32,15 @@ def _parse_response(
             response_200.append(componentsschemasruntime_servers_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["RuntimeServer"]]:
+) -> Response[Union[Error, list["RuntimeServer"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -53,7 +53,7 @@ def sync_detailed(
     parent_name: str,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["RuntimeServer"]]:
+) -> Response[Union[Error, list["RuntimeServer"]]]:
     """Return an array of runtime servers' settings
 
      Returns an array of all servers' runtime settings.
@@ -66,7 +66,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['RuntimeServer']]
+        Response[Union[Error, list['RuntimeServer']]]
     """
 
     kwargs = _get_kwargs(
@@ -84,7 +84,7 @@ def sync(
     parent_name: str,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["RuntimeServer"]]:
+) -> Optional[Union[Error, list["RuntimeServer"]]]:
     """Return an array of runtime servers' settings
 
      Returns an array of all servers' runtime settings.
@@ -97,7 +97,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['RuntimeServer']
+        Union[Error, list['RuntimeServer']]
     """
 
     return sync_detailed(
@@ -110,7 +110,7 @@ async def asyncio_detailed(
     parent_name: str,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["RuntimeServer"]]:
+) -> Response[Union[Error, list["RuntimeServer"]]]:
     """Return an array of runtime servers' settings
 
      Returns an array of all servers' runtime settings.
@@ -123,7 +123,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['RuntimeServer']]
+        Response[Union[Error, list['RuntimeServer']]]
     """
 
     kwargs = _get_kwargs(
@@ -139,7 +139,7 @@ async def asyncio(
     parent_name: str,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["RuntimeServer"]]:
+) -> Optional[Union[Error, list["RuntimeServer"]]]:
     """Return an array of runtime servers' settings
 
      Returns an array of all servers' runtime settings.
@@ -152,7 +152,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['RuntimeServer']
+        Union[Error, list['RuntimeServer']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_all_server_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_all_server_backend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.server import Server
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Server"]]:
+) -> Union[Error, list["Server"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemasservers_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Server"]]:
+) -> Response[Union[Error, list["Server"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Server"]]:
+) -> Response[Union[Error, list["Server"]]]:
     """Return an array of servers
 
      Returns an array of all servers that are configured in specified backend.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Server']]
+        Response[Union[Error, list['Server']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Server"]]:
+) -> Optional[Union[Error, list["Server"]]]:
     """Return an array of servers
 
      Returns an array of all servers that are configured in specified backend.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Server']
+        Union[Error, list['Server']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Server"]]:
+) -> Response[Union[Error, list["Server"]]]:
     """Return an array of servers
 
      Returns an array of all servers that are configured in specified backend.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Server']]
+        Response[Union[Error, list['Server']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Server"]]:
+) -> Optional[Union[Error, list["Server"]]]:
     """Return an array of servers
 
      Returns an array of all servers that are configured in specified backend.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Server']
+        Union[Error, list['Server']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_all_server_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_all_server_peer.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.server import Server
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Server"]]:
+) -> Union[Error, list["Server"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemasservers_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Server"]]:
+) -> Response[Union[Error, list["Server"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Server"]]:
+) -> Response[Union[Error, list["Server"]]]:
     """Return an array of servers
 
      Returns an array of all servers that are configured in specified backend.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Server']]
+        Response[Union[Error, list['Server']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Server"]]:
+) -> Optional[Union[Error, list["Server"]]]:
     """Return an array of servers
 
      Returns an array of all servers that are configured in specified backend.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Server']
+        Union[Error, list['Server']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Server"]]:
+) -> Response[Union[Error, list["Server"]]]:
     """Return an array of servers
 
      Returns an array of all servers that are configured in specified backend.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Server']]
+        Response[Union[Error, list['Server']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Server"]]:
+) -> Optional[Union[Error, list["Server"]]]:
     """Return an array of servers
 
      Returns an array of all servers that are configured in specified backend.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Server']
+        Union[Error, list['Server']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_all_server_ring.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_all_server_ring.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.server import Server
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Server"]]:
+) -> Union[Error, list["Server"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemasservers_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Server"]]:
+) -> Response[Union[Error, list["Server"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Server"]]:
+) -> Response[Union[Error, list["Server"]]]:
     """Return an array of servers
 
      Returns an array of all servers that are configured in specified backend.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Server']]
+        Response[Union[Error, list['Server']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Server"]]:
+) -> Optional[Union[Error, list["Server"]]]:
     """Return an array of servers
 
      Returns an array of all servers that are configured in specified backend.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Server']
+        Union[Error, list['Server']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Server"]]:
+) -> Response[Union[Error, list["Server"]]]:
     """Return an array of servers
 
      Returns an array of all servers that are configured in specified backend.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Server']]
+        Response[Union[Error, list['Server']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Server"]]:
+) -> Optional[Union[Error, list["Server"]]]:
     """Return an array of servers
 
      Returns an array of all servers that are configured in specified backend.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Server']
+        Union[Error, list['Server']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_runtime_server.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_runtime_server.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.runtime_server import RuntimeServer
@@ -24,19 +23,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, RuntimeServer]]:
+) -> Union[Error, RuntimeServer]:
     if response.status_code == 200:
         response_200 = RuntimeServer.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_server_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_server_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server import Server
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Server]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Server]:
     if response.status_code == 200:
         response_200 = Server.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_server_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_server_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server import Server
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Server]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Server]:
     if response.status_code == 200:
         response_200 = Server.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_server_ring.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/get_server_ring.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server import Server
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Server]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Server]:
     if response.status_code == 200:
         response_200 = Server.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/replace_runtime_server.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/replace_runtime_server.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.runtime_server import RuntimeServer
@@ -23,9 +22,8 @@ def _get_kwargs(
         "url": f"/services/haproxy/runtime/backends/{parent_name}/servers/{name}",
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -34,23 +32,25 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, RuntimeServer]]:
+) -> Union[Error, RuntimeServer]:
     if response.status_code == 200:
         response_200 = RuntimeServer.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/replace_server_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/replace_server_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server import Server
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Server]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Server]:
     if response.status_code == 200:
         response_200 = Server.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Server.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/replace_server_peer.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/replace_server_peer.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server import Server
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Server]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Server]:
     if response.status_code == 200:
         response_200 = Server.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Server.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/replace_server_ring.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server/replace_server_ring.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server import Server
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Server]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Server]:
     if response.status_code == 200:
         response_200 = Server.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Server.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_switching_rule/create_server_switching_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_switching_rule/create_server_switching_rule.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server_switching_rule import ServerSwitchingRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, ServerSwitchingRule]]:
+) -> Union[Error, ServerSwitchingRule]:
     if response.status_code == 201:
         response_201 = ServerSwitchingRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = ServerSwitchingRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_switching_rule/delete_server_switching_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_switching_rule/delete_server_switching_rule.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_switching_rule/get_server_switching_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_switching_rule/get_server_switching_rule.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server_switching_rule import ServerSwitchingRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, ServerSwitchingRule]]:
+) -> Union[Error, ServerSwitchingRule]:
     if response.status_code == 200:
         response_200 = ServerSwitchingRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_switching_rule/get_server_switching_rules.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_switching_rule/get_server_switching_rules.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.server_switching_rule import ServerSwitchingRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["ServerSwitchingRule"]]:
+) -> Union[Error, list["ServerSwitchingRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasserver_switching_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["ServerSwitchingRule"]]:
+) -> Response[Union[Error, list["ServerSwitchingRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ServerSwitchingRule"]]:
+) -> Response[Union[Error, list["ServerSwitchingRule"]]]:
     """Return an array of all Server Switching Rules
 
      Returns all Backend Switching Rules that are configured in specified backend.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ServerSwitchingRule']]
+        Response[Union[Error, list['ServerSwitchingRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ServerSwitchingRule"]]:
+) -> Optional[Union[Error, list["ServerSwitchingRule"]]]:
     """Return an array of all Server Switching Rules
 
      Returns all Backend Switching Rules that are configured in specified backend.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ServerSwitchingRule']
+        Union[Error, list['ServerSwitchingRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ServerSwitchingRule"]]:
+) -> Response[Union[Error, list["ServerSwitchingRule"]]]:
     """Return an array of all Server Switching Rules
 
      Returns all Backend Switching Rules that are configured in specified backend.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ServerSwitchingRule']]
+        Response[Union[Error, list['ServerSwitchingRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ServerSwitchingRule"]]:
+) -> Optional[Union[Error, list["ServerSwitchingRule"]]]:
     """Return an array of all Server Switching Rules
 
      Returns all Backend Switching Rules that are configured in specified backend.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ServerSwitchingRule']
+        Union[Error, list['ServerSwitchingRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_switching_rule/replace_server_switching_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_switching_rule/replace_server_switching_rule.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server_switching_rule import ServerSwitchingRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, ServerSwitchingRule]]:
+) -> Union[Error, ServerSwitchingRule]:
     if response.status_code == 200:
         response_200 = ServerSwitchingRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = ServerSwitchingRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_switching_rule/replace_server_switching_rules.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_switching_rule/replace_server_switching_rules.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server_switching_rule import ServerSwitchingRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemasserver_switching_rules_item_data in body:
         componentsschemasserver_switching_rules_item = componentsschemasserver_switching_rules_item_data.to_dict()
-        _body.append(componentsschemasserver_switching_rules_item)
+        _kwargs["json"].append(componentsschemasserver_switching_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["ServerSwitchingRule"]]]:
+) -> Union[Error, list["ServerSwitchingRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemasserver_switching_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemasserver_switching_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_template/create_server_template.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_template/create_server_template.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server_template import ServerTemplate
@@ -36,9 +35,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -47,27 +45,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, ServerTemplate]]:
+) -> Union[Error, ServerTemplate]:
     if response.status_code == 201:
         response_201 = ServerTemplate.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = ServerTemplate.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_template/delete_server_template.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_template/delete_server_template.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_template/get_server_template.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_template/get_server_template.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server_template import ServerTemplate
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, ServerTemplate]]:
+) -> Union[Error, ServerTemplate]:
     if response.status_code == 200:
         response_200 = ServerTemplate.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_template/get_server_templates.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_template/get_server_templates.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.server_template import ServerTemplate
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["ServerTemplate"]]:
+) -> Union[Error, list["ServerTemplate"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasserver_templates_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["ServerTemplate"]]:
+) -> Response[Union[Error, list["ServerTemplate"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ServerTemplate"]]:
+) -> Response[Union[Error, list["ServerTemplate"]]]:
     """Return an array of server templates
 
      Returns an array of all server templates that are configured in specified backend.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ServerTemplate']]
+        Response[Union[Error, list['ServerTemplate']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ServerTemplate"]]:
+) -> Optional[Union[Error, list["ServerTemplate"]]]:
     """Return an array of server templates
 
      Returns an array of all server templates that are configured in specified backend.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ServerTemplate']
+        Union[Error, list['ServerTemplate']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["ServerTemplate"]]:
+) -> Response[Union[Error, list["ServerTemplate"]]]:
     """Return an array of server templates
 
      Returns an array of all server templates that are configured in specified backend.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ServerTemplate']]
+        Response[Union[Error, list['ServerTemplate']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["ServerTemplate"]]:
+) -> Optional[Union[Error, list["ServerTemplate"]]]:
     """Return an array of server templates
 
      Returns an array of all server templates that are configured in specified backend.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ServerTemplate']
+        Union[Error, list['ServerTemplate']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_template/replace_server_template.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/server_template/replace_server_template.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.server_template import ServerTemplate
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, ServerTemplate]]:
+) -> Union[Error, ServerTemplate]:
     if response.status_code == 200:
         response_200 = ServerTemplate.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = ServerTemplate.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/create_aws_region.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/create_aws_region.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.aws_region import AWSRegion
 from ...models.error import Error
@@ -21,34 +20,33 @@ def _get_kwargs(
         "url": "/service_discovery/aws",
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[AWSRegion, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[AWSRegion, Error]:
     if response.status_code == 201:
         response_201 = AWSRegion.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/create_consul.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/create_consul.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.consul_server import ConsulServer
 from ...models.error import Error
@@ -21,9 +20,8 @@ def _get_kwargs(
         "url": "/service_discovery/consul",
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -32,23 +30,25 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ConsulServer, Error]]:
+) -> Union[ConsulServer, Error]:
     if response.status_code == 201:
         response_201 = ConsulServer.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/delete_aws_region.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/delete_aws_region.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import Response
@@ -20,20 +19,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/delete_consul.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/delete_consul.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import Response
@@ -20,20 +19,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/get_aws_region.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/get_aws_region.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.aws_region import AWSRegion
 from ...models.error import Error
@@ -21,21 +20,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[AWSRegion, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[AWSRegion, Error]:
     if response.status_code == 200:
         response_200 = AWSRegion.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/get_aws_regions.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/get_aws_regions.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.aws_region import AWSRegion
+from ...models.error import Error
 from ...types import Response
 
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["AWSRegion"]]:
+) -> Union[Error, list["AWSRegion"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasaws_regions_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["AWSRegion"]]:
+) -> Response[Union[Error, list["AWSRegion"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["AWSRegion"]]:
+) -> Response[Union[Error, list["AWSRegion"]]]:
     """Return an array of all configured AWS regions
 
      Return all configured AWS regions.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['AWSRegion']]
+        Response[Union[Error, list['AWSRegion']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["AWSRegion"]]:
+) -> Optional[Union[Error, list["AWSRegion"]]]:
     """Return an array of all configured AWS regions
 
      Return all configured AWS regions.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['AWSRegion']
+        Union[Error, list['AWSRegion']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["AWSRegion"]]:
+) -> Response[Union[Error, list["AWSRegion"]]]:
     """Return an array of all configured AWS regions
 
      Return all configured AWS regions.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['AWSRegion']]
+        Response[Union[Error, list['AWSRegion']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["AWSRegion"]]:
+) -> Optional[Union[Error, list["AWSRegion"]]]:
     """Return an array of all configured AWS regions
 
      Return all configured AWS regions.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['AWSRegion']
+        Union[Error, list['AWSRegion']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/get_consul.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/get_consul.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.consul_server import ConsulServer
 from ...models.error import Error
@@ -23,19 +22,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ConsulServer, Error]]:
+) -> Union[ConsulServer, Error]:
     if response.status_code == 200:
         response_200 = ConsulServer.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/get_consuls.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/get_consuls.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.consul_server import ConsulServer
+from ...models.error import Error
 from ...types import Response
 
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["ConsulServer"]]:
+) -> Union[Error, list["ConsulServer"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasconsuls_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["ConsulServer"]]:
+) -> Response[Union[Error, list["ConsulServer"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["ConsulServer"]]:
+) -> Response[Union[Error, list["ConsulServer"]]]:
     """Return an array of all configured Consul servers
 
      Returns all configured Consul servers.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ConsulServer']]
+        Response[Union[Error, list['ConsulServer']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["ConsulServer"]]:
+) -> Optional[Union[Error, list["ConsulServer"]]]:
     """Return an array of all configured Consul servers
 
      Returns all configured Consul servers.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ConsulServer']
+        Union[Error, list['ConsulServer']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["ConsulServer"]]:
+) -> Response[Union[Error, list["ConsulServer"]]]:
     """Return an array of all configured Consul servers
 
      Returns all configured Consul servers.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ConsulServer']]
+        Response[Union[Error, list['ConsulServer']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["ConsulServer"]]:
+) -> Optional[Union[Error, list["ConsulServer"]]]:
     """Return an array of all configured Consul servers
 
      Returns all configured Consul servers.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ConsulServer']
+        Union[Error, list['ConsulServer']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/replace_aws_region.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/replace_aws_region.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.aws_region import AWSRegion
 from ...models.error import Error
@@ -22,34 +21,33 @@ def _get_kwargs(
         "url": f"/service_discovery/aws/{id}",
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[AWSRegion, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[AWSRegion, Error]:
     if response.status_code == 200:
         response_200 = AWSRegion.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/replace_consul.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/service_discovery/replace_consul.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.consul_server import ConsulServer
 from ...models.error import Error
@@ -22,9 +21,8 @@ def _get_kwargs(
         "url": f"/service_discovery/consul/{id}",
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -33,23 +31,25 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ConsulServer, Error]]:
+) -> Union[ConsulServer, Error]:
     if response.status_code == 200:
         response_200 = ConsulServer.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/sites/create_site.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/sites/create_site.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.site import Site
@@ -35,38 +34,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Site]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Site]:
     if response.status_code == 201:
         response_201 = Site.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Site.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/sites/delete_site.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/sites/delete_site.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/sites/get_site.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/sites/get_site.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.site import Site
@@ -30,21 +29,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Site]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Site]:
     if response.status_code == 200:
         response_200 = Site.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/sites/get_sites.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/sites/get_sites.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.site import Site
 from ...types import UNSET, Response, Unset
 
@@ -28,7 +28,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[list["Site"]]:
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Union[Error, list["Site"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -38,13 +40,15 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
             response_200.append(componentsschemassites_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[list["Site"]]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, list["Site"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -57,7 +61,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Site"]]:
+) -> Response[Union[Error, list["Site"]]]:
     """Return an array of sites
 
      Returns an array of all configured sites.
@@ -70,7 +74,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Site']]
+        Response[Union[Error, list['Site']]]
     """
 
     kwargs = _get_kwargs(
@@ -88,7 +92,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Site"]]:
+) -> Optional[Union[Error, list["Site"]]]:
     """Return an array of sites
 
      Returns an array of all configured sites.
@@ -101,7 +105,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Site']
+        Union[Error, list['Site']]
     """
 
     return sync_detailed(
@@ -114,7 +118,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Site"]]:
+) -> Response[Union[Error, list["Site"]]]:
     """Return an array of sites
 
      Returns an array of all configured sites.
@@ -127,7 +131,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Site']]
+        Response[Union[Error, list['Site']]]
     """
 
     kwargs = _get_kwargs(
@@ -143,7 +147,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Site"]]:
+) -> Optional[Union[Error, list["Site"]]]:
     """Return an array of sites
 
      Returns an array of all configured sites.
@@ -156,7 +160,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Site']
+        Union[Error, list['Site']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/sites/replace_site.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/sites/replace_site.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.site import Site
@@ -36,38 +35,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Site]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Site]:
     if response.status_code == 200:
         response_200 = Site.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Site.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/specification/get_specification.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/specification/get_specification.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.get_specification_response_200 import GetSpecificationResponse200
 from ...types import Response
 
@@ -20,20 +20,20 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[GetSpecificationResponse200]:
+) -> Union[Error, GetSpecificationResponse200]:
     if response.status_code == 200:
         response_200 = GetSpecificationResponse200.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[GetSpecificationResponse200]:
+) -> Response[Union[Error, GetSpecificationResponse200]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -45,7 +45,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[GetSpecificationResponse200]:
+) -> Response[Union[Error, GetSpecificationResponse200]]:
     """Data Plane API Specification
 
      Return Data Plane API OpenAPI specification
@@ -55,7 +55,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[GetSpecificationResponse200]
+        Response[Union[Error, GetSpecificationResponse200]]
     """
 
     kwargs = _get_kwargs()
@@ -70,7 +70,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[GetSpecificationResponse200]:
+) -> Optional[Union[Error, GetSpecificationResponse200]]:
     """Data Plane API Specification
 
      Return Data Plane API OpenAPI specification
@@ -80,7 +80,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        GetSpecificationResponse200
+        Union[Error, GetSpecificationResponse200]
     """
 
     return sync_detailed(
@@ -91,7 +91,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[GetSpecificationResponse200]:
+) -> Response[Union[Error, GetSpecificationResponse200]]:
     """Data Plane API Specification
 
      Return Data Plane API OpenAPI specification
@@ -101,7 +101,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[GetSpecificationResponse200]
+        Response[Union[Error, GetSpecificationResponse200]]
     """
 
     kwargs = _get_kwargs()
@@ -114,7 +114,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[GetSpecificationResponse200]:
+) -> Optional[Union[Error, GetSpecificationResponse200]]:
     """Data Plane API Specification
 
      Return Data Plane API OpenAPI specification
@@ -124,7 +124,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        GetSpecificationResponse200
+        Union[Error, GetSpecificationResponse200]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/specification_openapiv_3/get_openapiv_3_specification.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/specification_openapiv_3/get_openapiv_3_specification.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.get_openapiv_3_specification_response_200 import GetOpenapiv3SpecificationResponse200
 from ...types import Response
 
@@ -20,20 +20,20 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[GetOpenapiv3SpecificationResponse200]:
+) -> Union[Error, GetOpenapiv3SpecificationResponse200]:
     if response.status_code == 200:
         response_200 = GetOpenapiv3SpecificationResponse200.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[GetOpenapiv3SpecificationResponse200]:
+) -> Response[Union[Error, GetOpenapiv3SpecificationResponse200]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -45,7 +45,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[GetOpenapiv3SpecificationResponse200]:
+) -> Response[Union[Error, GetOpenapiv3SpecificationResponse200]]:
     """Data Plane API v3 Specification
 
      Return Data Plane API OpenAPI v3 specification
@@ -55,7 +55,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[GetOpenapiv3SpecificationResponse200]
+        Response[Union[Error, GetOpenapiv3SpecificationResponse200]]
     """
 
     kwargs = _get_kwargs()
@@ -70,7 +70,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[GetOpenapiv3SpecificationResponse200]:
+) -> Optional[Union[Error, GetOpenapiv3SpecificationResponse200]]:
     """Data Plane API v3 Specification
 
      Return Data Plane API OpenAPI v3 specification
@@ -80,7 +80,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        GetOpenapiv3SpecificationResponse200
+        Union[Error, GetOpenapiv3SpecificationResponse200]
     """
 
     return sync_detailed(
@@ -91,7 +91,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[GetOpenapiv3SpecificationResponse200]:
+) -> Response[Union[Error, GetOpenapiv3SpecificationResponse200]]:
     """Data Plane API v3 Specification
 
      Return Data Plane API OpenAPI v3 specification
@@ -101,7 +101,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[GetOpenapiv3SpecificationResponse200]
+        Response[Union[Error, GetOpenapiv3SpecificationResponse200]]
     """
 
     kwargs = _get_kwargs()
@@ -114,7 +114,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[GetOpenapiv3SpecificationResponse200]:
+) -> Optional[Union[Error, GetOpenapiv3SpecificationResponse200]]:
     """Data Plane API v3 Specification
 
      Return Data Plane API OpenAPI v3 specification
@@ -124,7 +124,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        GetOpenapiv3SpecificationResponse200
+        Union[Error, GetOpenapiv3SpecificationResponse200]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/create_spoe.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/create_spoe.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_spoe_body import CreateSpoeBody
 from ...models.error import Error
@@ -21,32 +20,30 @@ def _get_kwargs(
         "url": "/services/haproxy/spoe/spoe_files",
     }
 
-    _body = body.to_multipart()
-
-    _kwargs["files"] = _body
+    _kwargs["files"] = body.to_multipart()
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, str]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, str]:
     if response.status_code == 201:
         response_201 = cast(str, response.json())
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/create_spoe_agent.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/create_spoe_agent.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.spoe_agent import SPOEAgent
@@ -34,34 +33,33 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SPOEAgent]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, SPOEAgent]:
     if response.status_code == 201:
         response_201 = SPOEAgent.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/create_spoe_group.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/create_spoe_group.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.spoe_group import SPOEGroup
@@ -34,34 +33,33 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SPOEGroup]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, SPOEGroup]:
     if response.status_code == 201:
         response_201 = SPOEGroup.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/create_spoe_message.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/create_spoe_message.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.spoe_message import SPOEMessage
@@ -34,9 +33,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -45,23 +43,25 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SPOEMessage]]:
+) -> Union[Error, SPOEMessage]:
     if response.status_code == 201:
         response_201 = SPOEMessage.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/create_spoe_scope.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/create_spoe_scope.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -32,33 +31,32 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body
+    _kwargs["json"] = body
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, str]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, str]:
     if response.status_code == 201:
         response_201 = cast(str, response.json())
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/delete_spoe_agent.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/delete_spoe_agent.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -34,20 +33,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/delete_spoe_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/delete_spoe_file.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import Response
@@ -20,20 +19,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/delete_spoe_group.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/delete_spoe_group.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -34,20 +33,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/delete_spoe_message.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/delete_spoe_message.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -34,20 +33,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/delete_spoe_scope.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/delete_spoe_scope.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -33,20 +32,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_all_spoe_agent.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_all_spoe_agent.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.spoe_agent import SPOEAgent
 from ...types import UNSET, Response, Unset
 
@@ -32,7 +32,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["SPOEAgent"]]:
+) -> Union[Error, list["SPOEAgent"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -42,15 +42,15 @@ def _parse_response(
             response_200.append(componentsschemasspoe_agents_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["SPOEAgent"]]:
+) -> Response[Union[Error, list["SPOEAgent"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["SPOEAgent"]]:
+) -> Response[Union[Error, list["SPOEAgent"]]]:
     """Return an array of spoe agents in one scope
 
      Returns an array of all configured spoe agents in one scope.
@@ -80,7 +80,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SPOEAgent']]
+        Response[Union[Error, list['SPOEAgent']]]
     """
 
     kwargs = _get_kwargs(
@@ -102,7 +102,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["SPOEAgent"]]:
+) -> Optional[Union[Error, list["SPOEAgent"]]]:
     """Return an array of spoe agents in one scope
 
      Returns an array of all configured spoe agents in one scope.
@@ -117,7 +117,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SPOEAgent']
+        Union[Error, list['SPOEAgent']]
     """
 
     return sync_detailed(
@@ -134,7 +134,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["SPOEAgent"]]:
+) -> Response[Union[Error, list["SPOEAgent"]]]:
     """Return an array of spoe agents in one scope
 
      Returns an array of all configured spoe agents in one scope.
@@ -149,7 +149,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SPOEAgent']]
+        Response[Union[Error, list['SPOEAgent']]]
     """
 
     kwargs = _get_kwargs(
@@ -169,7 +169,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["SPOEAgent"]]:
+) -> Optional[Union[Error, list["SPOEAgent"]]]:
     """Return an array of spoe agents in one scope
 
      Returns an array of all configured spoe agents in one scope.
@@ -184,7 +184,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SPOEAgent']
+        Union[Error, list['SPOEAgent']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_all_spoe_files.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_all_spoe_files.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import Response
@@ -18,21 +17,20 @@ def _get_kwargs() -> dict[str, Any]:
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list[str]]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, list[str]]:
     if response.status_code == 200:
         response_200 = cast(list[str], response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_all_spoe_group.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_all_spoe_group.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.spoe_group import SPOEGroup
 from ...types import UNSET, Response, Unset
 
@@ -32,7 +32,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["SPOEGroup"]]:
+) -> Union[Error, list["SPOEGroup"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -42,15 +42,15 @@ def _parse_response(
             response_200.append(componentsschemasspoe_groups_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["SPOEGroup"]]:
+) -> Response[Union[Error, list["SPOEGroup"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["SPOEGroup"]]:
+) -> Response[Union[Error, list["SPOEGroup"]]]:
     """Return an array of SPOE groups
 
      Returns an array of all configured SPOE groups in one SPOE scope.
@@ -80,7 +80,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SPOEGroup']]
+        Response[Union[Error, list['SPOEGroup']]]
     """
 
     kwargs = _get_kwargs(
@@ -102,7 +102,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["SPOEGroup"]]:
+) -> Optional[Union[Error, list["SPOEGroup"]]]:
     """Return an array of SPOE groups
 
      Returns an array of all configured SPOE groups in one SPOE scope.
@@ -117,7 +117,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SPOEGroup']
+        Union[Error, list['SPOEGroup']]
     """
 
     return sync_detailed(
@@ -134,7 +134,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["SPOEGroup"]]:
+) -> Response[Union[Error, list["SPOEGroup"]]]:
     """Return an array of SPOE groups
 
      Returns an array of all configured SPOE groups in one SPOE scope.
@@ -149,7 +149,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SPOEGroup']]
+        Response[Union[Error, list['SPOEGroup']]]
     """
 
     kwargs = _get_kwargs(
@@ -169,7 +169,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["SPOEGroup"]]:
+) -> Optional[Union[Error, list["SPOEGroup"]]]:
     """Return an array of SPOE groups
 
      Returns an array of all configured SPOE groups in one SPOE scope.
@@ -184,7 +184,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SPOEGroup']
+        Union[Error, list['SPOEGroup']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_all_spoe_message.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_all_spoe_message.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.spoe_message import SPOEMessage
 from ...types import UNSET, Response, Unset
 
@@ -32,7 +32,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["SPOEMessage"]]:
+) -> Union[Error, list["SPOEMessage"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -42,15 +42,15 @@ def _parse_response(
             response_200.append(componentsschemasspoe_messages_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["SPOEMessage"]]:
+) -> Response[Union[Error, list["SPOEMessage"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["SPOEMessage"]]:
+) -> Response[Union[Error, list["SPOEMessage"]]]:
     """Return an array of spoe messages in one scope
 
      Returns an array of all configured spoe messages in one scope.
@@ -80,7 +80,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SPOEMessage']]
+        Response[Union[Error, list['SPOEMessage']]]
     """
 
     kwargs = _get_kwargs(
@@ -102,7 +102,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["SPOEMessage"]]:
+) -> Optional[Union[Error, list["SPOEMessage"]]]:
     """Return an array of spoe messages in one scope
 
      Returns an array of all configured spoe messages in one scope.
@@ -117,7 +117,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SPOEMessage']
+        Union[Error, list['SPOEMessage']]
     """
 
     return sync_detailed(
@@ -134,7 +134,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["SPOEMessage"]]:
+) -> Response[Union[Error, list["SPOEMessage"]]]:
     """Return an array of spoe messages in one scope
 
      Returns an array of all configured spoe messages in one scope.
@@ -149,7 +149,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SPOEMessage']]
+        Response[Union[Error, list['SPOEMessage']]]
     """
 
     kwargs = _get_kwargs(
@@ -169,7 +169,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["SPOEMessage"]]:
+) -> Optional[Union[Error, list["SPOEMessage"]]]:
     """Return an array of spoe messages in one scope
 
      Returns an array of all configured spoe messages in one scope.
@@ -184,7 +184,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SPOEMessage']
+        Union[Error, list['SPOEMessage']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_all_spoe_scope.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_all_spoe_scope.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...types import UNSET, Response, Unset
 
 
@@ -28,18 +28,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[list[str]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, list[str]]:
     if response.status_code == 200:
         response_200 = cast(list[str], response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[list[str]]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, list[str]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -53,7 +55,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list[str]]:
+) -> Response[Union[Error, list[str]]]:
     """Return an array of spoe scopes
 
      Returns an array of all configured spoe scopes.
@@ -67,7 +69,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list[str]]
+        Response[Union[Error, list[str]]]
     """
 
     kwargs = _get_kwargs(
@@ -87,7 +89,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list[str]]:
+) -> Optional[Union[Error, list[str]]]:
     """Return an array of spoe scopes
 
      Returns an array of all configured spoe scopes.
@@ -101,7 +103,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list[str]
+        Union[Error, list[str]]
     """
 
     return sync_detailed(
@@ -116,7 +118,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list[str]]:
+) -> Response[Union[Error, list[str]]]:
     """Return an array of spoe scopes
 
      Returns an array of all configured spoe scopes.
@@ -130,7 +132,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list[str]]
+        Response[Union[Error, list[str]]]
     """
 
     kwargs = _get_kwargs(
@@ -148,7 +150,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list[str]]:
+) -> Optional[Union[Error, list[str]]]:
     """Return an array of spoe scopes
 
      Returns an array of all configured spoe scopes.
@@ -162,7 +164,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list[str]
+        Union[Error, list[str]]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_one_spoe_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_one_spoe_file.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.get_one_spoe_file_response_200 import GetOneSpoeFileResponse200
@@ -23,19 +22,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, GetOneSpoeFileResponse200]]:
+) -> Union[Error, GetOneSpoeFileResponse200]:
     if response.status_code == 200:
         response_200 = GetOneSpoeFileResponse200.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_spoe_agent.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_spoe_agent.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.spoe_agent import SPOEAgent
@@ -32,21 +31,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SPOEAgent]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, SPOEAgent]:
     if response.status_code == 200:
         response_200 = SPOEAgent.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_spoe_configuration_version.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_spoe_configuration_version.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -29,20 +28,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, int]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, int]:
     if response.status_code == 200:
         response_200 = cast(int, response.json())
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_spoe_group.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_spoe_group.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.spoe_group import SPOEGroup
@@ -32,21 +31,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SPOEGroup]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, SPOEGroup]:
     if response.status_code == 200:
         response_200 = SPOEGroup.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_spoe_message.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_spoe_message.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.spoe_message import SPOEMessage
@@ -34,19 +33,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SPOEMessage]]:
+) -> Union[Error, SPOEMessage]:
     if response.status_code == 200:
         response_200 = SPOEMessage.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_spoe_scope.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/get_spoe_scope.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -30,20 +29,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, str]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, str]:
     if response.status_code == 200:
         response_200 = cast(str, response.json())
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/replace_spoe_agent.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/replace_spoe_agent.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.spoe_agent import SPOEAgent
@@ -35,34 +34,33 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SPOEAgent]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, SPOEAgent]:
     if response.status_code == 200:
         response_200 = SPOEAgent.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/replace_spoe_group.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/replace_spoe_group.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.spoe_group import SPOEGroup
@@ -35,34 +34,33 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SPOEGroup]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, SPOEGroup]:
     if response.status_code == 200:
         response_200 = SPOEGroup.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/replace_spoe_message.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe/replace_spoe_message.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.spoe_message import SPOEMessage
@@ -35,9 +34,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -46,23 +44,25 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SPOEMessage]]:
+) -> Union[Error, SPOEMessage]:
     if response.status_code == 200:
         response_200 = SPOEMessage.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe_transactions/commit_spoe_transaction.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe_transactions/commit_spoe_transaction.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.spoe_configuration_transaction import SPOEConfigurationTransaction
@@ -33,27 +32,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SPOEConfigurationTransaction]]:
+) -> Union[Error, SPOEConfigurationTransaction]:
     if response.status_code == 200:
         response_200 = SPOEConfigurationTransaction.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = SPOEConfigurationTransaction.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe_transactions/delete_spoe_transaction.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe_transactions/delete_spoe_transaction.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import Response
@@ -21,20 +20,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe_transactions/get_all_spoe_transaction.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe_transactions/get_all_spoe_transaction.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.get_all_spoe_transaction_status import GetAllSpoeTransactionStatus
 from ...models.spoe_configuration_transaction import SPOEConfigurationTransaction
 from ...types import UNSET, Response, Unset
@@ -36,7 +36,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["SPOEConfigurationTransaction"]]:
+) -> Union[Error, list["SPOEConfigurationTransaction"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -48,15 +48,15 @@ def _parse_response(
             response_200.append(componentsschemasspoe_transactions_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["SPOEConfigurationTransaction"]]:
+) -> Response[Union[Error, list["SPOEConfigurationTransaction"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -70,7 +70,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     status: Union[Unset, GetAllSpoeTransactionStatus] = UNSET,
-) -> Response[list["SPOEConfigurationTransaction"]]:
+) -> Response[Union[Error, list["SPOEConfigurationTransaction"]]]:
     """Return list of SPOE configuration transactions.
 
      Returns a list of SPOE configuration transactions. Transactions can be filtered by their status.
@@ -84,7 +84,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SPOEConfigurationTransaction']]
+        Response[Union[Error, list['SPOEConfigurationTransaction']]]
     """
 
     kwargs = _get_kwargs(
@@ -104,7 +104,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     status: Union[Unset, GetAllSpoeTransactionStatus] = UNSET,
-) -> Optional[list["SPOEConfigurationTransaction"]]:
+) -> Optional[Union[Error, list["SPOEConfigurationTransaction"]]]:
     """Return list of SPOE configuration transactions.
 
      Returns a list of SPOE configuration transactions. Transactions can be filtered by their status.
@@ -118,7 +118,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SPOEConfigurationTransaction']
+        Union[Error, list['SPOEConfigurationTransaction']]
     """
 
     return sync_detailed(
@@ -133,7 +133,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     status: Union[Unset, GetAllSpoeTransactionStatus] = UNSET,
-) -> Response[list["SPOEConfigurationTransaction"]]:
+) -> Response[Union[Error, list["SPOEConfigurationTransaction"]]]:
     """Return list of SPOE configuration transactions.
 
      Returns a list of SPOE configuration transactions. Transactions can be filtered by their status.
@@ -147,7 +147,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SPOEConfigurationTransaction']]
+        Response[Union[Error, list['SPOEConfigurationTransaction']]]
     """
 
     kwargs = _get_kwargs(
@@ -165,7 +165,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     status: Union[Unset, GetAllSpoeTransactionStatus] = UNSET,
-) -> Optional[list["SPOEConfigurationTransaction"]]:
+) -> Optional[Union[Error, list["SPOEConfigurationTransaction"]]]:
     """Return list of SPOE configuration transactions.
 
      Returns a list of SPOE configuration transactions. Transactions can be filtered by their status.
@@ -179,7 +179,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SPOEConfigurationTransaction']
+        Union[Error, list['SPOEConfigurationTransaction']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe_transactions/get_spoe_transaction.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe_transactions/get_spoe_transaction.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.spoe_configuration_transaction import SPOEConfigurationTransaction
@@ -24,19 +23,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SPOEConfigurationTransaction]]:
+) -> Union[Error, SPOEConfigurationTransaction]:
     if response.status_code == 200:
         response_200 = SPOEConfigurationTransaction.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe_transactions/start_spoe_transaction.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/spoe_transactions/start_spoe_transaction.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.spoe_configuration_transaction import SPOEConfigurationTransaction
 from ...models.start_spoe_transaction_response_429 import StartSpoeTransactionResponse429
 from ...types import UNSET, Response
@@ -32,24 +32,25 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]:
+) -> Union[Error, SPOEConfigurationTransaction, StartSpoeTransactionResponse429]:
     if response.status_code == 201:
         response_201 = SPOEConfigurationTransaction.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 429:
         response_429 = StartSpoeTransactionResponse429.from_dict(response.json())
 
         return response_429
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]:
+) -> Response[Union[Error, SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +64,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     version: int,
-) -> Response[Union[SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]:
+) -> Response[Union[Error, SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]:
     """Start a new transaction
 
      Starts a new transaction and returns it's id
@@ -77,7 +78,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]
+        Response[Union[Error, SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +98,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     version: int,
-) -> Optional[Union[SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]:
+) -> Optional[Union[Error, SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]:
     """Start a new transaction
 
      Starts a new transaction and returns it's id
@@ -111,7 +112,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[SPOEConfigurationTransaction, StartSpoeTransactionResponse429]
+        Union[Error, SPOEConfigurationTransaction, StartSpoeTransactionResponse429]
     """
 
     return sync_detailed(
@@ -126,7 +127,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     version: int,
-) -> Response[Union[SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]:
+) -> Response[Union[Error, SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]:
     """Start a new transaction
 
      Starts a new transaction and returns it's id
@@ -140,7 +141,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]
+        Response[Union[Error, SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +159,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     version: int,
-) -> Optional[Union[SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]:
+) -> Optional[Union[Error, SPOEConfigurationTransaction, StartSpoeTransactionResponse429]]:
     """Start a new transaction
 
      Starts a new transaction and returns it's id
@@ -172,7 +173,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[SPOEConfigurationTransaction, StartSpoeTransactionResponse429]
+        Union[Error, SPOEConfigurationTransaction, StartSpoeTransactionResponse429]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_front_use/create_ssl_front_use.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_front_use/create_ssl_front_use.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ssl_frontend_use_certificate import SSLFrontendUseCertificate
@@ -36,9 +35,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -47,27 +45,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SSLFrontendUseCertificate]]:
+) -> Union[Error, SSLFrontendUseCertificate]:
     if response.status_code == 201:
         response_201 = SSLFrontendUseCertificate.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = SSLFrontendUseCertificate.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_front_use/delete_ssl_front_use.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_front_use/delete_ssl_front_use.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_front_use/get_all_ssl_front_uses.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_front_use/get_all_ssl_front_uses.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.ssl_frontend_use_certificate import SSLFrontendUseCertificate
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["SSLFrontendUseCertificate"]]:
+) -> Union[Error, list["SSLFrontendUseCertificate"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasssl_front_uses_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["SSLFrontendUseCertificate"]]:
+) -> Response[Union[Error, list["SSLFrontendUseCertificate"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["SSLFrontendUseCertificate"]]:
+) -> Response[Union[Error, list["SSLFrontendUseCertificate"]]]:
     """Return an array of SSLFrontUses
 
      Returns an array of all SSLFrontUses that are configured in specified frontend.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SSLFrontendUseCertificate']]
+        Response[Union[Error, list['SSLFrontendUseCertificate']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["SSLFrontendUseCertificate"]]:
+) -> Optional[Union[Error, list["SSLFrontendUseCertificate"]]]:
     """Return an array of SSLFrontUses
 
      Returns an array of all SSLFrontUses that are configured in specified frontend.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SSLFrontendUseCertificate']
+        Union[Error, list['SSLFrontendUseCertificate']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["SSLFrontendUseCertificate"]]:
+) -> Response[Union[Error, list["SSLFrontendUseCertificate"]]]:
     """Return an array of SSLFrontUses
 
      Returns an array of all SSLFrontUses that are configured in specified frontend.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SSLFrontendUseCertificate']]
+        Response[Union[Error, list['SSLFrontendUseCertificate']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["SSLFrontendUseCertificate"]]:
+) -> Optional[Union[Error, list["SSLFrontendUseCertificate"]]]:
     """Return an array of SSLFrontUses
 
      Returns an array of all SSLFrontUses that are configured in specified frontend.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SSLFrontendUseCertificate']
+        Union[Error, list['SSLFrontendUseCertificate']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_front_use/get_ssl_front_use.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_front_use/get_ssl_front_use.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ssl_frontend_use_certificate import SSLFrontendUseCertificate
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SSLFrontendUseCertificate]]:
+) -> Union[Error, SSLFrontendUseCertificate]:
     if response.status_code == 200:
         response_200 = SSLFrontendUseCertificate.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_front_use/replace_ssl_front_use.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_front_use/replace_ssl_front_use.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ssl_frontend_use_certificate import SSLFrontendUseCertificate
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SSLFrontendUseCertificate]]:
+) -> Union[Error, SSLFrontendUseCertificate]:
     if response.status_code == 200:
         response_200 = SSLFrontendUseCertificate.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = SSLFrontendUseCertificate.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/add_ca_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/add_ca_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.add_ca_entry_body import AddCaEntryBody
 from ...models.error import Error
@@ -23,29 +22,26 @@ def _get_kwargs(
         "url": f"/services/haproxy/runtime/ssl_ca_files/{name}/entries",
     }
 
-    _body = body.to_multipart()
-
-    _kwargs["files"] = _body
+    _kwargs["files"] = body.to_multipart()
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SSLFile]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, SSLFile]:
     if response.status_code == 201:
         response_201 = SSLFile.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/add_crt_list_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/add_crt_list_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ssl_crt_list_entry import SSLCrtListEntry
@@ -29,33 +28,32 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 201:
         response_201 = cast(Any, None)
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/create_ca_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/create_ca_file.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_ca_file_body import CreateCaFileBody
 from ...models.error import Error
@@ -21,32 +20,30 @@ def _get_kwargs(
         "url": "/services/haproxy/runtime/ssl_ca_files",
     }
 
-    _body = body.to_multipart()
-
-    _kwargs["files"] = _body
+    _kwargs["files"] = body.to_multipart()
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 201:
         response_201 = cast(Any, None)
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/create_cert.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/create_cert.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_cert_body import CreateCertBody
 from ...models.error import Error
@@ -21,32 +20,30 @@ def _get_kwargs(
         "url": "/services/haproxy/runtime/ssl_certs",
     }
 
-    _body = body.to_multipart()
-
-    _kwargs["files"] = _body
+    _kwargs["files"] = body.to_multipart()
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 201:
         response_201 = cast(Any, None)
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/create_crl.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/create_crl.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_crl_body import CreateCrlBody
 from ...models.error import Error
@@ -21,32 +20,30 @@ def _get_kwargs(
         "url": "/services/haproxy/runtime/ssl_crl_files",
     }
 
-    _body = body.to_multipart()
-
-    _kwargs["files"] = _body
+    _kwargs["files"] = body.to_multipart()
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 201:
         response_201 = cast(Any, None)
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/delete_ca_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/delete_ca_file.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import Response
@@ -20,20 +19,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/delete_cert.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/delete_cert.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import Response
@@ -20,20 +19,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/delete_crl.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/delete_crl.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import Response
@@ -20,20 +19,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/delete_crt_list_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/delete_crt_list_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -34,24 +33,24 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_all_ca_files.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_all_ca_files.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.ssl_file_1 import SSLFile1
 from ...types import Response
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["SSLFile1"]]:
+) -> Union[Error, list["SSLFile1"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasssl_ca_files_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["SSLFile1"]]:
+) -> Response[Union[Error, list["SSLFile1"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["SSLFile1"]]:
+) -> Response[Union[Error, list["SSLFile1"]]]:
     """Return an array of all SSL CA files
 
      Returns all SSL CA files using the runtime socket.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SSLFile1']]
+        Response[Union[Error, list['SSLFile1']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["SSLFile1"]]:
+) -> Optional[Union[Error, list["SSLFile1"]]]:
     """Return an array of all SSL CA files
 
      Returns all SSL CA files using the runtime socket.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SSLFile1']
+        Union[Error, list['SSLFile1']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["SSLFile1"]]:
+) -> Response[Union[Error, list["SSLFile1"]]]:
     """Return an array of all SSL CA files
 
      Returns all SSL CA files using the runtime socket.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SSLFile1']]
+        Response[Union[Error, list['SSLFile1']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["SSLFile1"]]:
+) -> Optional[Union[Error, list["SSLFile1"]]]:
     """Return an array of all SSL CA files
 
      Returns all SSL CA files using the runtime socket.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SSLFile1']
+        Union[Error, list['SSLFile1']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_all_certs.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_all_certs.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.ssl_file import SSLFile
 from ...types import Response
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["SSLFile"]]:
+) -> Union[Error, list["SSLFile"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasssl_certificates_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["SSLFile"]]:
+) -> Response[Union[Error, list["SSLFile"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["SSLFile"]]:
+) -> Response[Union[Error, list["SSLFile"]]]:
     """Return a list of SSL certificate files
 
      Returns certificate files descriptions from runtime.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SSLFile']]
+        Response[Union[Error, list['SSLFile']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["SSLFile"]]:
+) -> Optional[Union[Error, list["SSLFile"]]]:
     """Return a list of SSL certificate files
 
      Returns certificate files descriptions from runtime.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SSLFile']
+        Union[Error, list['SSLFile']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["SSLFile"]]:
+) -> Response[Union[Error, list["SSLFile"]]]:
     """Return a list of SSL certificate files
 
      Returns certificate files descriptions from runtime.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SSLFile']]
+        Response[Union[Error, list['SSLFile']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["SSLFile"]]:
+) -> Optional[Union[Error, list["SSLFile"]]]:
     """Return a list of SSL certificate files
 
      Returns certificate files descriptions from runtime.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SSLFile']
+        Union[Error, list['SSLFile']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_all_crl.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_all_crl.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.sslcrl_file import SSLCRLFile
 from ...types import Response
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["SSLCRLFile"]]:
+) -> Union[Error, list["SSLCRLFile"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasssl_crls_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["SSLCRLFile"]]:
+) -> Response[Union[Error, list["SSLCRLFile"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["SSLCRLFile"]]:
+) -> Response[Union[Error, list["SSLCRLFile"]]]:
     """Return an array of all the CRL files
 
      Returns all the certificate revocation list files using the runtime socket.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SSLCRLFile']]
+        Response[Union[Error, list['SSLCRLFile']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["SSLCRLFile"]]:
+) -> Optional[Union[Error, list["SSLCRLFile"]]]:
     """Return an array of all the CRL files
 
      Returns all the certificate revocation list files using the runtime socket.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SSLCRLFile']
+        Union[Error, list['SSLCRLFile']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["SSLCRLFile"]]:
+) -> Response[Union[Error, list["SSLCRLFile"]]]:
     """Return an array of all the CRL files
 
      Returns all the certificate revocation list files using the runtime socket.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SSLCRLFile']]
+        Response[Union[Error, list['SSLCRLFile']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["SSLCRLFile"]]:
+) -> Optional[Union[Error, list["SSLCRLFile"]]]:
     """Return an array of all the CRL files
 
      Returns all the certificate revocation list files using the runtime socket.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SSLCRLFile']
+        Union[Error, list['SSLCRLFile']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_all_crt_list_entries.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_all_crt_list_entries.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.ssl_crt_list_entry import SSLCrtListEntry
 from ...types import UNSET, Response
 
@@ -30,7 +30,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["SSLCrtListEntry"]]:
+) -> Union[Error, list["SSLCrtListEntry"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -42,15 +42,15 @@ def _parse_response(
             response_200.append(componentsschemasssl_crt_list_entries_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["SSLCrtListEntry"]]:
+) -> Response[Union[Error, list["SSLCrtListEntry"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     name: str,
-) -> Response[list["SSLCrtListEntry"]]:
+) -> Response[Union[Error, list["SSLCrtListEntry"]]]:
     """Get all the entries inside a crt-list
 
      Returns an array of entries present inside the given crt-list file. Their index can be used to
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SSLCrtListEntry']]
+        Response[Union[Error, list['SSLCrtListEntry']]]
     """
 
     kwargs = _get_kwargs(
@@ -95,7 +95,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     name: str,
-) -> Optional[list["SSLCrtListEntry"]]:
+) -> Optional[Union[Error, list["SSLCrtListEntry"]]]:
     """Get all the entries inside a crt-list
 
      Returns an array of entries present inside the given crt-list file. Their index can be used to
@@ -109,7 +109,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SSLCrtListEntry']
+        Union[Error, list['SSLCrtListEntry']]
     """
 
     return sync_detailed(
@@ -122,7 +122,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     name: str,
-) -> Response[list["SSLCrtListEntry"]]:
+) -> Response[Union[Error, list["SSLCrtListEntry"]]]:
     """Get all the entries inside a crt-list
 
      Returns an array of entries present inside the given crt-list file. Their index can be used to
@@ -136,7 +136,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SSLCrtListEntry']]
+        Response[Union[Error, list['SSLCrtListEntry']]]
     """
 
     kwargs = _get_kwargs(
@@ -152,7 +152,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     name: str,
-) -> Optional[list["SSLCrtListEntry"]]:
+) -> Optional[Union[Error, list["SSLCrtListEntry"]]]:
     """Get all the entries inside a crt-list
 
      Returns an array of entries present inside the given crt-list file. Their index can be used to
@@ -166,7 +166,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SSLCrtListEntry']
+        Union[Error, list['SSLCrtListEntry']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_all_crt_lists.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_all_crt_lists.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.ssl_crt_list import SSLCrtList
 from ...types import Response
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["SSLCrtList"]]:
+) -> Union[Error, list["SSLCrtList"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasssl_crt_lists_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["SSLCrtList"]]:
+) -> Response[Union[Error, list["SSLCrtList"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["SSLCrtList"]]:
+) -> Response[Union[Error, list["SSLCrtList"]]]:
     """Get the list of all crt-list files
 
      Returns an array of crt-list file descriptions from runtime.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SSLCrtList']]
+        Response[Union[Error, list['SSLCrtList']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["SSLCrtList"]]:
+) -> Optional[Union[Error, list["SSLCrtList"]]]:
     """Get the list of all crt-list files
 
      Returns an array of crt-list file descriptions from runtime.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SSLCrtList']
+        Union[Error, list['SSLCrtList']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["SSLCrtList"]]:
+) -> Response[Union[Error, list["SSLCrtList"]]]:
     """Get the list of all crt-list files
 
      Returns an array of crt-list file descriptions from runtime.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['SSLCrtList']]
+        Response[Union[Error, list['SSLCrtList']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["SSLCrtList"]]:
+) -> Optional[Union[Error, list["SSLCrtList"]]]:
     """Get the list of all crt-list files
 
      Returns an array of crt-list file descriptions from runtime.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['SSLCrtList']
+        Union[Error, list['SSLCrtList']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_ca_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_ca_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ssl_file import SSLFile
@@ -22,21 +21,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SSLFile]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, SSLFile]:
     if response.status_code == 200:
         response_200 = SSLFile.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_ca_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_ca_file.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ssl_file_1 import SSLFile1
@@ -21,21 +20,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SSLFile1]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, SSLFile1]:
     if response.status_code == 200:
         response_200 = SSLFile1.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_cert.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_cert.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.ssl_file import SSLFile
 from ...types import Response
 
@@ -20,18 +20,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[SSLFile]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, SSLFile]:
     if response.status_code == 200:
         response_200 = SSLFile.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[SSLFile]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, SSLFile]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -44,7 +46,7 @@ def sync_detailed(
     name: str,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[SSLFile]:
+) -> Response[Union[Error, SSLFile]]:
     """Return one structured certificate
 
      Returns one structured certificate using the runtime socket.
@@ -57,7 +59,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[SSLFile]
+        Response[Union[Error, SSLFile]]
     """
 
     kwargs = _get_kwargs(
@@ -75,7 +77,7 @@ def sync(
     name: str,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[SSLFile]:
+) -> Optional[Union[Error, SSLFile]]:
     """Return one structured certificate
 
      Returns one structured certificate using the runtime socket.
@@ -88,7 +90,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        SSLFile
+        Union[Error, SSLFile]
     """
 
     return sync_detailed(
@@ -101,7 +103,7 @@ async def asyncio_detailed(
     name: str,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[SSLFile]:
+) -> Response[Union[Error, SSLFile]]:
     """Return one structured certificate
 
      Returns one structured certificate using the runtime socket.
@@ -114,7 +116,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[SSLFile]
+        Response[Union[Error, SSLFile]]
     """
 
     kwargs = _get_kwargs(
@@ -130,7 +132,7 @@ async def asyncio(
     name: str,
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[SSLFile]:
+) -> Optional[Union[Error, SSLFile]]:
     """Return one structured certificate
 
      Returns one structured certificate using the runtime socket.
@@ -143,7 +145,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        SSLFile
+        Union[Error, SSLFile]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_crl.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/get_crl.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.one_crl_entry import OneCRLEntry
@@ -32,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["OneCRLEntry"]]]:
+) -> Union[Error, list["OneCRLEntry"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -42,14 +41,15 @@ def _parse_response(
             response_200.append(componentsschemasssl_crl_entries_item)
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/replace_cert.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/replace_cert.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.replace_cert_body import ReplaceCertBody
@@ -22,28 +21,25 @@ def _get_kwargs(
         "url": f"/services/haproxy/runtime/ssl_certs/{name}",
     }
 
-    _body = body.to_multipart()
-
-    _kwargs["files"] = _body
+    _kwargs["files"] = body.to_multipart()
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 200:
         response_200 = cast(Any, None)
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/replace_crl.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/replace_crl.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.replace_crl_body import ReplaceCrlBody
@@ -22,28 +21,25 @@ def _get_kwargs(
         "url": f"/services/haproxy/runtime/ssl_crl_files/{name}",
     }
 
-    _body = body.to_multipart()
-
-    _kwargs["files"] = _body
+    _kwargs["files"] = body.to_multipart()
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 200:
         response_200 = cast(Any, None)
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/set_ca_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/ssl_runtime/set_ca_file.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.set_ca_file_body import SetCaFileBody
@@ -22,28 +21,25 @@ def _get_kwargs(
         "url": f"/services/haproxy/runtime/ssl_ca_files/{name}",
     }
 
-    _body = body.to_multipart()
-
-    _kwargs["files"] = _body
+    _kwargs["files"] = body.to_multipart()
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 200:
         response_200 = cast(Any, None)
         return response_200
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stats/get_stats.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stats/get_stats.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.get_stats_type import GetStatsType
 from ...models.stats_array import StatsArray
 from ...types import UNSET, Response, Unset
@@ -39,22 +39,27 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[StatsArray]:
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Union[Error, StatsArray]:
     if response.status_code == 200:
         response_200 = StatsArray.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 500:
         response_500 = StatsArray.from_dict(response.json())
 
         return response_500
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[StatsArray]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, StatsArray]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +74,7 @@ def sync_detailed(
     type_: Union[Unset, GetStatsType] = UNSET,
     name: Union[Unset, str] = UNSET,
     parent: Union[Unset, str] = UNSET,
-) -> Response[StatsArray]:
+) -> Response[Union[Error, StatsArray]]:
     """Gets stats
 
      Getting stats from the HAProxy.
@@ -84,7 +89,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[StatsArray]
+        Response[Union[Error, StatsArray]]
     """
 
     kwargs = _get_kwargs(
@@ -106,7 +111,7 @@ def sync(
     type_: Union[Unset, GetStatsType] = UNSET,
     name: Union[Unset, str] = UNSET,
     parent: Union[Unset, str] = UNSET,
-) -> Optional[StatsArray]:
+) -> Optional[Union[Error, StatsArray]]:
     """Gets stats
 
      Getting stats from the HAProxy.
@@ -121,7 +126,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        StatsArray
+        Union[Error, StatsArray]
     """
 
     return sync_detailed(
@@ -138,7 +143,7 @@ async def asyncio_detailed(
     type_: Union[Unset, GetStatsType] = UNSET,
     name: Union[Unset, str] = UNSET,
     parent: Union[Unset, str] = UNSET,
-) -> Response[StatsArray]:
+) -> Response[Union[Error, StatsArray]]:
     """Gets stats
 
      Getting stats from the HAProxy.
@@ -153,7 +158,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[StatsArray]
+        Response[Union[Error, StatsArray]]
     """
 
     kwargs = _get_kwargs(
@@ -173,7 +178,7 @@ async def asyncio(
     type_: Union[Unset, GetStatsType] = UNSET,
     name: Union[Unset, str] = UNSET,
     parent: Union[Unset, str] = UNSET,
-) -> Optional[StatsArray]:
+) -> Optional[Union[Error, StatsArray]]:
     """Gets stats
 
      Getting stats from the HAProxy.
@@ -188,7 +193,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        StatsArray
+        Union[Error, StatsArray]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_rule/create_stick_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_rule/create_stick_rule.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.stick_rule import StickRule
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, StickRule]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, StickRule]:
     if response.status_code == 201:
         response_201 = StickRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = StickRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_rule/delete_stick_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_rule/delete_stick_rule.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_rule/get_stick_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_rule/get_stick_rule.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.stick_rule import StickRule
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, StickRule]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, StickRule]:
     if response.status_code == 200:
         response_200 = StickRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_rule/get_stick_rules.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_rule/get_stick_rules.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.stick_rule import StickRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["StickRule"]]:
+) -> Union[Error, list["StickRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemasstick_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["StickRule"]]:
+) -> Response[Union[Error, list["StickRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["StickRule"]]:
+) -> Response[Union[Error, list["StickRule"]]]:
     """Return an array of all Stick Rules
 
      Returns all Stick Rules that are configured in specified backend.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['StickRule']]
+        Response[Union[Error, list['StickRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["StickRule"]]:
+) -> Optional[Union[Error, list["StickRule"]]]:
     """Return an array of all Stick Rules
 
      Returns all Stick Rules that are configured in specified backend.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['StickRule']
+        Union[Error, list['StickRule']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["StickRule"]]:
+) -> Response[Union[Error, list["StickRule"]]]:
     """Return an array of all Stick Rules
 
      Returns all Stick Rules that are configured in specified backend.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['StickRule']]
+        Response[Union[Error, list['StickRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["StickRule"]]:
+) -> Optional[Union[Error, list["StickRule"]]]:
     """Return an array of all Stick Rules
 
      Returns all Stick Rules that are configured in specified backend.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['StickRule']
+        Union[Error, list['StickRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_rule/replace_stick_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_rule/replace_stick_rule.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.stick_rule import StickRule
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, StickRule]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, StickRule]:
     if response.status_code == 200:
         response_200 = StickRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = StickRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_rule/replace_stick_rules.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_rule/replace_stick_rules.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.stick_rule import StickRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemasstick_rules_item_data in body:
         componentsschemasstick_rules_item = componentsschemasstick_rules_item_data.to_dict()
-        _body.append(componentsschemasstick_rules_item)
+        _kwargs["json"].append(componentsschemasstick_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["StickRule"]]]:
+) -> Union[Error, list["StickRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemasstick_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemasstick_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_table/get_stick_table.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_table/get_stick_table.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.stick_table import StickTable
@@ -23,19 +22,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, StickTable]]:
+) -> Union[Error, StickTable]:
     if response.status_code == 200:
         response_200 = StickTable.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_table/get_stick_table_entries.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_table/get_stick_table_entries.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.stick_table_entry import StickTableEntry
 from ...types import UNSET, Response, Unset
 
@@ -40,7 +40,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["StickTableEntry"]]:
+) -> Union[Error, list["StickTableEntry"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -52,15 +52,15 @@ def _parse_response(
             response_200.append(componentsschemasstick_table_entries_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["StickTableEntry"]]:
+) -> Response[Union[Error, list["StickTableEntry"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -77,7 +77,7 @@ def sync_detailed(
     key: Union[Unset, str] = UNSET,
     count: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Response[list["StickTableEntry"]]:
+) -> Response[Union[Error, list["StickTableEntry"]]]:
     """Return Stick Table Entries
 
      Returns an array of all entries in a given stick tables.
@@ -94,7 +94,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['StickTableEntry']]
+        Response[Union[Error, list['StickTableEntry']]]
     """
 
     kwargs = _get_kwargs(
@@ -120,7 +120,7 @@ def sync(
     key: Union[Unset, str] = UNSET,
     count: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Optional[list["StickTableEntry"]]:
+) -> Optional[Union[Error, list["StickTableEntry"]]]:
     """Return Stick Table Entries
 
      Returns an array of all entries in a given stick tables.
@@ -137,7 +137,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['StickTableEntry']
+        Union[Error, list['StickTableEntry']]
     """
 
     return sync_detailed(
@@ -158,7 +158,7 @@ async def asyncio_detailed(
     key: Union[Unset, str] = UNSET,
     count: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Response[list["StickTableEntry"]]:
+) -> Response[Union[Error, list["StickTableEntry"]]]:
     """Return Stick Table Entries
 
      Returns an array of all entries in a given stick tables.
@@ -175,7 +175,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['StickTableEntry']]
+        Response[Union[Error, list['StickTableEntry']]]
     """
 
     kwargs = _get_kwargs(
@@ -199,7 +199,7 @@ async def asyncio(
     key: Union[Unset, str] = UNSET,
     count: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Optional[list["StickTableEntry"]]:
+) -> Optional[Union[Error, list["StickTableEntry"]]]:
     """Return Stick Table Entries
 
      Returns an array of all entries in a given stick tables.
@@ -216,7 +216,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['StickTableEntry']
+        Union[Error, list['StickTableEntry']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_table/get_stick_tables.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_table/get_stick_tables.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.stick_table import StickTable
 from ...types import Response
 
@@ -20,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["StickTable"]]:
+) -> Union[Error, list["StickTable"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -30,15 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasstick_tables_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["StickTable"]]:
+) -> Response[Union[Error, list["StickTable"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["StickTable"]]:
+) -> Response[Union[Error, list["StickTable"]]]:
     """Return Stick Tables
 
      Returns an array of all stick tables.
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['StickTable']]
+        Response[Union[Error, list['StickTable']]]
     """
 
     kwargs = _get_kwargs()
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["StickTable"]]:
+) -> Optional[Union[Error, list["StickTable"]]]:
     """Return Stick Tables
 
      Returns an array of all stick tables.
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['StickTable']
+        Union[Error, list['StickTable']]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[list["StickTable"]]:
+) -> Response[Union[Error, list["StickTable"]]]:
     """Return Stick Tables
 
      Returns an array of all stick tables.
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['StickTable']]
+        Response[Union[Error, list['StickTable']]]
     """
 
     kwargs = _get_kwargs()
@@ -119,7 +119,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[list["StickTable"]]:
+) -> Optional[Union[Error, list["StickTable"]]]:
     """Return Stick Tables
 
      Returns an array of all stick tables.
@@ -129,7 +129,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['StickTable']
+        Union[Error, list['StickTable']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_table/set_stick_table_entries.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/stick_table/set_stick_table_entries.py
@@ -1,10 +1,10 @@
 from http import HTTPStatus
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.set_stick_table_entries_body import SetStickTableEntriesBody
 from ...types import Response
 
@@ -21,25 +21,27 @@ def _get_kwargs(
         "url": f"/services/haproxy/runtime/stick_tables/{parent_name}/entries",
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
-        return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+        response_204 = cast(Any, None)
+        return response_204
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Any]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, Error]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -53,7 +55,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: SetStickTableEntriesBody,
-) -> Response[Any]:
+) -> Response[Union[Any, Error]]:
     """Set Entry to Stick Table
 
      Create or update a stick-table entry in the table.
@@ -67,7 +69,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[Union[Any, Error]]
     """
 
     kwargs = _get_kwargs(
@@ -82,12 +84,12 @@ def sync_detailed(
     return _build_response(client=client, response=response)
 
 
-async def asyncio_detailed(
+def sync(
     parent_name: str,
     *,
     client: Union[AuthenticatedClient, Client],
     body: SetStickTableEntriesBody,
-) -> Response[Any]:
+) -> Optional[Union[Any, Error]]:
     """Set Entry to Stick Table
 
      Create or update a stick-table entry in the table.
@@ -101,7 +103,36 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Union[Any, Error]
+    """
+
+    return sync_detailed(
+        parent_name=parent_name,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    parent_name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: SetStickTableEntriesBody,
+) -> Response[Union[Any, Error]]:
+    """Set Entry to Stick Table
+
+     Create or update a stick-table entry in the table.
+
+    Args:
+        parent_name (str):
+        body (SetStickTableEntriesBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, Error]]
     """
 
     kwargs = _get_kwargs(
@@ -112,3 +143,34 @@ async def asyncio_detailed(
     response = await client.get_async_httpx_client().request(**kwargs)
 
     return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    parent_name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: SetStickTableEntriesBody,
+) -> Optional[Union[Any, Error]]:
+    """Set Entry to Stick Table
+
+     Create or update a stick-table entry in the table.
+
+    Args:
+        parent_name (str):
+        body (SetStickTableEntriesBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, Error]
+    """
+
+    return (
+        await asyncio_detailed(
+            parent_name=parent_name,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/create_storage_general_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/create_storage_general_file.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_storage_general_file_body import CreateStorageGeneralFileBody
 from ...models.error import Error
@@ -22,9 +21,7 @@ def _get_kwargs(
         "url": "/services/haproxy/storage/general",
     }
 
-    _body = body.to_multipart()
-
-    _kwargs["files"] = _body
+    _kwargs["files"] = body.to_multipart()
 
     _kwargs["headers"] = headers
     return _kwargs
@@ -32,23 +29,25 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, GeneralUseFile]]:
+) -> Union[Error, GeneralUseFile]:
     if response.status_code == 201:
         response_201 = GeneralUseFile.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/create_storage_map_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/create_storage_map_file.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_storage_map_file_body import CreateStorageMapFileBody
 from ...models.error import Error
@@ -22,33 +21,31 @@ def _get_kwargs(
         "url": "/services/haproxy/storage/maps",
     }
 
-    _body = body.to_multipart()
-
-    _kwargs["files"] = _body
+    _kwargs["files"] = body.to_multipart()
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, MapFile]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, MapFile]:
     if response.status_code == 201:
         response_201 = MapFile.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/create_storage_ssl_certificate.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/create_storage_ssl_certificate.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_storage_ssl_certificate_body import CreateStorageSSLCertificateBody
 from ...models.error import Error
@@ -33,37 +32,36 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_multipart()
-
-    _kwargs["files"] = _body
+    _kwargs["files"] = body.to_multipart()
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SSLFile]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, SSLFile]:
     if response.status_code == 201:
         response_201 = SSLFile.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = SSLFile.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/create_storage_ssl_crt_list_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/create_storage_ssl_crt_list_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ssl_crt_list_entry import SSLCrtListEntry
@@ -30,9 +29,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -41,26 +39,29 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error, SSLCrtListEntry]]:
+) -> Union[Any, Error, SSLCrtListEntry]:
     if response.status_code == 201:
         response_201 = SSLCrtListEntry.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/create_storage_ssl_crt_list_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/create_storage_ssl_crt_list_file.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.create_storage_ssl_crt_list_file_body import CreateStorageSSLCrtListFileBody
 from ...models.error import Error
@@ -30,9 +29,7 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_multipart()
-
-    _kwargs["files"] = _body
+    _kwargs["files"] = body.to_multipart()
 
     _kwargs["headers"] = headers
     return _kwargs
@@ -40,27 +37,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SSLCRTListFile]]:
+) -> Union[Error, SSLCRTListFile]:
     if response.status_code == 201:
         response_201 = SSLCRTListFile.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = SSLCRTListFile.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/delete_storage_general_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/delete_storage_general_file.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import Response
@@ -20,20 +19,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/delete_storage_map.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/delete_storage_map.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import Response
@@ -20,20 +19,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/delete_storage_ssl_certificate.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/delete_storage_ssl_certificate.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -32,23 +31,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/delete_storage_ssl_crt_list_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/delete_storage_ssl_crt_list_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,27 +34,28 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/delete_storage_ssl_crt_list_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/delete_storage_ssl_crt_list_file.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -32,23 +31,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_all_storage_general_files.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_all_storage_general_files.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.general_use_file import GeneralUseFile
@@ -21,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["GeneralUseFile"]]]:
+) -> Union[Error, list["GeneralUseFile"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -31,14 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasgeneral_files_item)
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_all_storage_map_files.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_all_storage_map_files.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.map_file import MapFile
@@ -21,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["MapFile"]]]:
+) -> Union[Error, list["MapFile"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -31,14 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasmaps_item)
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_all_storage_ssl_certificates.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_all_storage_ssl_certificates.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ssl_file import SSLFile
@@ -21,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["SSLFile"]]]:
+) -> Union[Error, list["SSLFile"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -31,14 +30,15 @@ def _parse_response(
             response_200.append(componentsschemasssl_certificates_item)
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_all_storage_ssl_crt_list_files.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_all_storage_ssl_crt_list_files.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.sslcrt_list_file import SSLCRTListFile
@@ -21,7 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["SSLCRTListFile"]]]:
+) -> Union[Error, list["SSLCRTListFile"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -33,14 +32,15 @@ def _parse_response(
             response_200.append(componentsschemasssl_crt_list_files_item)
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_one_storage_general_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_one_storage_general_file.py
@@ -4,7 +4,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import File, Response
@@ -21,21 +20,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, File]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, File]:
     if response.status_code == 200:
         response_200 = File(payload=BytesIO(response.content))
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_one_storage_map.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_one_storage_map.py
@@ -4,7 +4,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import File, Response
@@ -21,21 +20,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, File]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, File]:
     if response.status_code == 200:
         response_200 = File(payload=BytesIO(response.content))
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_one_storage_ssl_certificate.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_one_storage_ssl_certificate.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ssl_file import SSLFile
@@ -21,21 +20,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, SSLFile]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, SSLFile]:
     if response.status_code == 200:
         response_200 = SSLFile.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_one_storage_ssl_crt_list_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_one_storage_ssl_crt_list_file.py
@@ -4,7 +4,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import File, Response
@@ -21,21 +20,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, File]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, File]:
     if response.status_code == 200:
         response_200 = File(payload=BytesIO(response.content))
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_storage_ssl_crt_list_entries.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/get_storage_ssl_crt_list_entries.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.ssl_crt_list_entry import SSLCrtListEntry
@@ -23,7 +22,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["SSLCrtListEntry"]]]:
+) -> Union[Error, list["SSLCrtListEntry"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -35,14 +34,15 @@ def _parse_response(
             response_200.append(componentsschemasssl_crt_list_entries_item)
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/replace_storage_general_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/replace_storage_general_file.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.replace_storage_general_file_body import ReplaceStorageGeneralFileBody
@@ -33,35 +32,34 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_multipart()
-
-    _kwargs["files"] = _body
+    _kwargs["files"] = body.to_multipart()
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/replace_storage_map_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/replace_storage_map_file.py
@@ -1,0 +1,224 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    name: str,
+    *,
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    params: dict[str, Any] = {}
+
+    params["skip_reload"] = skip_reload
+
+    params["force_reload"] = force_reload
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": f"/services/haproxy/storage/maps/{name}",
+        "params": params,
+    }
+
+    _kwargs["content"] = body
+
+    headers["Content-Type"] = "text/plain"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
+    if response.status_code == 202:
+        response_202 = cast(Any, None)
+        return response_202
+
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 400:
+        response_400 = Error.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 404:
+        response_404 = Error.from_dict(response.json())
+
+        return response_404
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, Error]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> Response[Union[Any, Error]]:
+    """Replace contents of a managed map file on disk
+
+     Replaces the contents of a managed map file on disk
+
+    Args:
+        name (str):
+        skip_reload (Union[Unset, bool]):  Default: False.
+        force_reload (Union[Unset, bool]):  Default: False.
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, Error]]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+        body=body,
+        skip_reload=skip_reload,
+        force_reload=force_reload,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> Optional[Union[Any, Error]]:
+    """Replace contents of a managed map file on disk
+
+     Replaces the contents of a managed map file on disk
+
+    Args:
+        name (str):
+        skip_reload (Union[Unset, bool]):  Default: False.
+        force_reload (Union[Unset, bool]):  Default: False.
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, Error]
+    """
+
+    return sync_detailed(
+        name=name,
+        client=client,
+        body=body,
+        skip_reload=skip_reload,
+        force_reload=force_reload,
+    ).parsed
+
+
+async def asyncio_detailed(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> Response[Union[Any, Error]]:
+    """Replace contents of a managed map file on disk
+
+     Replaces the contents of a managed map file on disk
+
+    Args:
+        name (str):
+        skip_reload (Union[Unset, bool]):  Default: False.
+        force_reload (Union[Unset, bool]):  Default: False.
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, Error]]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+        body=body,
+        skip_reload=skip_reload,
+        force_reload=force_reload,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> Optional[Union[Any, Error]]:
+    """Replace contents of a managed map file on disk
+
+     Replaces the contents of a managed map file on disk
+
+    Args:
+        name (str):
+        skip_reload (Union[Unset, bool]):  Default: False.
+        force_reload (Union[Unset, bool]):  Default: False.
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, Error]
+    """
+
+    return (
+        await asyncio_detailed(
+            name=name,
+            client=client,
+            body=body,
+            skip_reload=skip_reload,
+            force_reload=force_reload,
+        )
+    ).parsed

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/replace_storage_ssl_certificate.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/replace_storage_ssl_certificate.py
@@ -1,0 +1,227 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...models.ssl_file import SSLFile
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    name: str,
+    *,
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    params: dict[str, Any] = {}
+
+    params["skip_reload"] = skip_reload
+
+    params["force_reload"] = force_reload
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": f"/services/haproxy/storage/ssl_certificates/{name}",
+        "params": params,
+    }
+
+    _kwargs["content"] = body
+
+    headers["Content-Type"] = "text/plain"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, SSLFile]:
+    if response.status_code == 200:
+        response_200 = SSLFile.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 202:
+        response_202 = SSLFile.from_dict(response.json())
+
+        return response_202
+
+    if response.status_code == 400:
+        response_400 = Error.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 404:
+        response_404 = Error.from_dict(response.json())
+
+        return response_404
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, SSLFile]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> Response[Union[Error, SSLFile]]:
+    """Replace SSL certificates on disk
+
+     Replaces SSL certificate on disk.
+
+    Args:
+        name (str):
+        skip_reload (Union[Unset, bool]):  Default: False.
+        force_reload (Union[Unset, bool]):  Default: False.
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Error, SSLFile]]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+        body=body,
+        skip_reload=skip_reload,
+        force_reload=force_reload,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> Optional[Union[Error, SSLFile]]:
+    """Replace SSL certificates on disk
+
+     Replaces SSL certificate on disk.
+
+    Args:
+        name (str):
+        skip_reload (Union[Unset, bool]):  Default: False.
+        force_reload (Union[Unset, bool]):  Default: False.
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Error, SSLFile]
+    """
+
+    return sync_detailed(
+        name=name,
+        client=client,
+        body=body,
+        skip_reload=skip_reload,
+        force_reload=force_reload,
+    ).parsed
+
+
+async def asyncio_detailed(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> Response[Union[Error, SSLFile]]:
+    """Replace SSL certificates on disk
+
+     Replaces SSL certificate on disk.
+
+    Args:
+        name (str):
+        skip_reload (Union[Unset, bool]):  Default: False.
+        force_reload (Union[Unset, bool]):  Default: False.
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Error, SSLFile]]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+        body=body,
+        skip_reload=skip_reload,
+        force_reload=force_reload,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> Optional[Union[Error, SSLFile]]:
+    """Replace SSL certificates on disk
+
+     Replaces SSL certificate on disk.
+
+    Args:
+        name (str):
+        skip_reload (Union[Unset, bool]):  Default: False.
+        force_reload (Union[Unset, bool]):  Default: False.
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Error, SSLFile]
+    """
+
+    return (
+        await asyncio_detailed(
+            name=name,
+            client=client,
+            body=body,
+            skip_reload=skip_reload,
+            force_reload=force_reload,
+        )
+    ).parsed

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/replace_storage_ssl_crt_list_file.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/storage/replace_storage_ssl_crt_list_file.py
@@ -1,0 +1,229 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...models.sslcrt_list_file import SSLCRTListFile
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    name: str,
+    *,
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    params: dict[str, Any] = {}
+
+    params["skip_reload"] = skip_reload
+
+    params["force_reload"] = force_reload
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": f"/services/haproxy/storage/ssl_crt_lists/{name}",
+        "params": params,
+    }
+
+    _kwargs["content"] = body
+
+    headers["Content-Type"] = "text/plain"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Union[Error, SSLCRTListFile]:
+    if response.status_code == 200:
+        response_200 = SSLCRTListFile.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 202:
+        response_202 = SSLCRTListFile.from_dict(response.json())
+
+        return response_202
+
+    if response.status_code == 400:
+        response_400 = Error.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 404:
+        response_404 = Error.from_dict(response.json())
+
+        return response_404
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, SSLCRTListFile]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> Response[Union[Error, SSLCRTListFile]]:
+    """Replace a certificate lists on disk
+
+     Replaces a certificate list on disk.
+
+    Args:
+        name (str):
+        skip_reload (Union[Unset, bool]):  Default: False.
+        force_reload (Union[Unset, bool]):  Default: False.
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Error, SSLCRTListFile]]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+        body=body,
+        skip_reload=skip_reload,
+        force_reload=force_reload,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> Optional[Union[Error, SSLCRTListFile]]:
+    """Replace a certificate lists on disk
+
+     Replaces a certificate list on disk.
+
+    Args:
+        name (str):
+        skip_reload (Union[Unset, bool]):  Default: False.
+        force_reload (Union[Unset, bool]):  Default: False.
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Error, SSLCRTListFile]
+    """
+
+    return sync_detailed(
+        name=name,
+        client=client,
+        body=body,
+        skip_reload=skip_reload,
+        force_reload=force_reload,
+    ).parsed
+
+
+async def asyncio_detailed(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> Response[Union[Error, SSLCRTListFile]]:
+    """Replace a certificate lists on disk
+
+     Replaces a certificate list on disk.
+
+    Args:
+        name (str):
+        skip_reload (Union[Unset, bool]):  Default: False.
+        force_reload (Union[Unset, bool]):  Default: False.
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Error, SSLCRTListFile]]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+        body=body,
+        skip_reload=skip_reload,
+        force_reload=force_reload,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: str,
+    skip_reload: Union[Unset, bool] = False,
+    force_reload: Union[Unset, bool] = False,
+) -> Optional[Union[Error, SSLCRTListFile]]:
+    """Replace a certificate lists on disk
+
+     Replaces a certificate list on disk.
+
+    Args:
+        name (str):
+        skip_reload (Union[Unset, bool]):  Default: False.
+        force_reload (Union[Unset, bool]):  Default: False.
+        body (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Error, SSLCRTListFile]
+    """
+
+    return (
+        await asyncio_detailed(
+            name=name,
+            client=client,
+            body=body,
+            skip_reload=skip_reload,
+            force_reload=force_reload,
+        )
+    ).parsed

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/table/create_table.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/table/create_table.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.table import Table
@@ -36,38 +35,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Table]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Table]:
     if response.status_code == 201:
         response_201 = Table.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Table.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/table/delete_table.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/table/delete_table.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/table/get_table.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/table/get_table.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.table import Table
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Table]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Table]:
     if response.status_code == 200:
         response_200 = Table.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/table/get_tables.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/table/get_tables.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.table import Table
 from ...types import UNSET, Response, Unset
 
@@ -29,7 +29,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[list["Table"]]:
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Union[Error, list["Table"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -39,13 +41,15 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
             response_200.append(componentsschemastables_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[list["Table"]]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, list["Table"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -59,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Table"]]:
+) -> Response[Union[Error, list["Table"]]]:
     """Return an array of tables
 
      Returns an array of all tables that are configured in specified peer section.
@@ -73,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Table']]
+        Response[Union[Error, list['Table']]]
     """
 
     kwargs = _get_kwargs(
@@ -93,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Table"]]:
+) -> Optional[Union[Error, list["Table"]]]:
     """Return an array of tables
 
      Returns an array of all tables that are configured in specified peer section.
@@ -107,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Table']
+        Union[Error, list['Table']]
     """
 
     return sync_detailed(
@@ -122,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["Table"]]:
+) -> Response[Union[Error, list["Table"]]]:
     """Return an array of tables
 
      Returns an array of all tables that are configured in specified peer section.
@@ -136,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Table']]
+        Response[Union[Error, list['Table']]]
     """
 
     kwargs = _get_kwargs(
@@ -154,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["Table"]]:
+) -> Optional[Union[Error, list["Table"]]]:
     """Return an array of tables
 
      Returns an array of all tables that are configured in specified peer section.
@@ -168,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Table']
+        Union[Error, list['Table']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/table/replace_table.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/table/replace_table.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.table import Table
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Table]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Table]:
     if response.status_code == 200:
         response_200 = Table.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Table.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/create_tcp_check_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/create_tcp_check_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_check import TCPCheck
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPCheck]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, TCPCheck]:
     if response.status_code == 201:
         response_201 = TCPCheck.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = TCPCheck.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/create_tcp_check_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/create_tcp_check_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_check import TCPCheck
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPCheck]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, TCPCheck]:
     if response.status_code == 201:
         response_201 = TCPCheck.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = TCPCheck.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/delete_tcp_check_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/delete_tcp_check_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/delete_tcp_check_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/delete_tcp_check_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/get_all_tcp_check_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/get_all_tcp_check_backend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.tcp_check import TCPCheck
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["TCPCheck"]]:
+) -> Union[Error, list["TCPCheck"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemastcp_checks_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["TCPCheck"]]:
+) -> Response[Union[Error, list["TCPCheck"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPCheck"]]:
+) -> Response[Union[Error, list["TCPCheck"]]]:
     """Return an array of TCP checks
 
      Returns all TCP checks that are configured in specified parent.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPCheck']]
+        Response[Union[Error, list['TCPCheck']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPCheck"]]:
+) -> Optional[Union[Error, list["TCPCheck"]]]:
     """Return an array of TCP checks
 
      Returns all TCP checks that are configured in specified parent.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPCheck']
+        Union[Error, list['TCPCheck']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPCheck"]]:
+) -> Response[Union[Error, list["TCPCheck"]]]:
     """Return an array of TCP checks
 
      Returns all TCP checks that are configured in specified parent.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPCheck']]
+        Response[Union[Error, list['TCPCheck']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPCheck"]]:
+) -> Optional[Union[Error, list["TCPCheck"]]]:
     """Return an array of TCP checks
 
      Returns all TCP checks that are configured in specified parent.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPCheck']
+        Union[Error, list['TCPCheck']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/get_all_tcp_check_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/get_all_tcp_check_defaults.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.tcp_check import TCPCheck
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["TCPCheck"]]:
+) -> Union[Error, list["TCPCheck"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,15 +41,15 @@ def _parse_response(
             response_200.append(componentsschemastcp_checks_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["TCPCheck"]]:
+) -> Response[Union[Error, list["TCPCheck"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPCheck"]]:
+) -> Response[Union[Error, list["TCPCheck"]]]:
     """Return an array of TCP checks
 
      Returns all TCP checks that are configured in specified parent.
@@ -77,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPCheck']]
+        Response[Union[Error, list['TCPCheck']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPCheck"]]:
+) -> Optional[Union[Error, list["TCPCheck"]]]:
     """Return an array of TCP checks
 
      Returns all TCP checks that are configured in specified parent.
@@ -111,7 +111,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPCheck']
+        Union[Error, list['TCPCheck']]
     """
 
     return sync_detailed(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPCheck"]]:
+) -> Response[Union[Error, list["TCPCheck"]]]:
     """Return an array of TCP checks
 
      Returns all TCP checks that are configured in specified parent.
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPCheck']]
+        Response[Union[Error, list['TCPCheck']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +158,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPCheck"]]:
+) -> Optional[Union[Error, list["TCPCheck"]]]:
     """Return an array of TCP checks
 
      Returns all TCP checks that are configured in specified parent.
@@ -172,7 +172,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPCheck']
+        Union[Error, list['TCPCheck']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/get_tcp_check_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/get_tcp_check_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_check import TCPCheck
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPCheck]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, TCPCheck]:
     if response.status_code == 200:
         response_200 = TCPCheck.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/get_tcp_check_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/get_tcp_check_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_check import TCPCheck
@@ -31,21 +30,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPCheck]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, TCPCheck]:
     if response.status_code == 200:
         response_200 = TCPCheck.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/replace_all_tcp_check_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/replace_all_tcp_check_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_check import TCPCheck
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemastcp_checks_item_data in body:
         componentsschemastcp_checks_item = componentsschemastcp_checks_item_data.to_dict()
-        _body.append(componentsschemastcp_checks_item)
+        _kwargs["json"].append(componentsschemastcp_checks_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["TCPCheck"]]]:
+) -> Union[Error, list["TCPCheck"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemastcp_checks_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemastcp_checks_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/replace_all_tcp_check_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/replace_all_tcp_check_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_check import TCPCheck
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemastcp_checks_item_data in body:
         componentsschemastcp_checks_item = componentsschemastcp_checks_item_data.to_dict()
-        _body.append(componentsschemastcp_checks_item)
+        _kwargs["json"].append(componentsschemastcp_checks_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["TCPCheck"]]]:
+) -> Union[Error, list["TCPCheck"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -60,6 +58,7 @@ def _parse_response(
             response_200.append(componentsschemastcp_checks_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -69,14 +68,15 @@ def _parse_response(
             response_202.append(componentsschemastcp_checks_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/replace_tcp_check_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/replace_tcp_check_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_check import TCPCheck
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPCheck]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, TCPCheck]:
     if response.status_code == 200:
         response_200 = TCPCheck.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = TCPCheck.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/replace_tcp_check_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_check/replace_tcp_check_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_check import TCPCheck
@@ -37,38 +36,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPCheck]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, TCPCheck]:
     if response.status_code == 200:
         response_200 = TCPCheck.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = TCPCheck.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/create_tcp_request_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/create_tcp_request_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPRequestRule]]:
+) -> Union[Error, TCPRequestRule]:
     if response.status_code == 201:
         response_201 = TCPRequestRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = TCPRequestRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/create_tcp_request_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/create_tcp_request_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPRequestRule]]:
+) -> Union[Error, TCPRequestRule]:
     if response.status_code == 201:
         response_201 = TCPRequestRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = TCPRequestRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/create_tcp_request_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/create_tcp_request_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPRequestRule]]:
+) -> Union[Error, TCPRequestRule]:
     if response.status_code == 201:
         response_201 = TCPRequestRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = TCPRequestRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/delete_tcp_request_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/delete_tcp_request_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/delete_tcp_request_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/delete_tcp_request_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/delete_tcp_request_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/delete_tcp_request_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/get_all_tcp_request_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/get_all_tcp_request_rule_backend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["TCPRequestRule"]]:
+) -> Union[Error, list["TCPRequestRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemastcp_request_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["TCPRequestRule"]]:
+) -> Response[Union[Error, list["TCPRequestRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPRequestRule"]]:
+) -> Response[Union[Error, list["TCPRequestRule"]]]:
     """Return an array of all TCP Request Rules
 
      Returns all TCP Request Rules that are configured in specified parent and parent type.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPRequestRule']]
+        Response[Union[Error, list['TCPRequestRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPRequestRule"]]:
+) -> Optional[Union[Error, list["TCPRequestRule"]]]:
     """Return an array of all TCP Request Rules
 
      Returns all TCP Request Rules that are configured in specified parent and parent type.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPRequestRule']
+        Union[Error, list['TCPRequestRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPRequestRule"]]:
+) -> Response[Union[Error, list["TCPRequestRule"]]]:
     """Return an array of all TCP Request Rules
 
      Returns all TCP Request Rules that are configured in specified parent and parent type.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPRequestRule']]
+        Response[Union[Error, list['TCPRequestRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPRequestRule"]]:
+) -> Optional[Union[Error, list["TCPRequestRule"]]]:
     """Return an array of all TCP Request Rules
 
      Returns all TCP Request Rules that are configured in specified parent and parent type.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPRequestRule']
+        Union[Error, list['TCPRequestRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/get_all_tcp_request_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/get_all_tcp_request_rule_defaults.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["TCPRequestRule"]]:
+) -> Union[Error, list["TCPRequestRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemastcp_request_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["TCPRequestRule"]]:
+) -> Response[Union[Error, list["TCPRequestRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPRequestRule"]]:
+) -> Response[Union[Error, list["TCPRequestRule"]]]:
     """Return an array of all TCP Request Rules
 
      Returns all TCP Request Rules that are configured in specified parent and parent type.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPRequestRule']]
+        Response[Union[Error, list['TCPRequestRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPRequestRule"]]:
+) -> Optional[Union[Error, list["TCPRequestRule"]]]:
     """Return an array of all TCP Request Rules
 
      Returns all TCP Request Rules that are configured in specified parent and parent type.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPRequestRule']
+        Union[Error, list['TCPRequestRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPRequestRule"]]:
+) -> Response[Union[Error, list["TCPRequestRule"]]]:
     """Return an array of all TCP Request Rules
 
      Returns all TCP Request Rules that are configured in specified parent and parent type.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPRequestRule']]
+        Response[Union[Error, list['TCPRequestRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPRequestRule"]]:
+) -> Optional[Union[Error, list["TCPRequestRule"]]]:
     """Return an array of all TCP Request Rules
 
      Returns all TCP Request Rules that are configured in specified parent and parent type.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPRequestRule']
+        Union[Error, list['TCPRequestRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/get_all_tcp_request_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/get_all_tcp_request_rule_frontend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["TCPRequestRule"]]:
+) -> Union[Error, list["TCPRequestRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemastcp_request_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["TCPRequestRule"]]:
+) -> Response[Union[Error, list["TCPRequestRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPRequestRule"]]:
+) -> Response[Union[Error, list["TCPRequestRule"]]]:
     """Return an array of all TCP Request Rules
 
      Returns all TCP Request Rules that are configured in specified parent and parent type.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPRequestRule']]
+        Response[Union[Error, list['TCPRequestRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPRequestRule"]]:
+) -> Optional[Union[Error, list["TCPRequestRule"]]]:
     """Return an array of all TCP Request Rules
 
      Returns all TCP Request Rules that are configured in specified parent and parent type.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPRequestRule']
+        Union[Error, list['TCPRequestRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPRequestRule"]]:
+) -> Response[Union[Error, list["TCPRequestRule"]]]:
     """Return an array of all TCP Request Rules
 
      Returns all TCP Request Rules that are configured in specified parent and parent type.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPRequestRule']]
+        Response[Union[Error, list['TCPRequestRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPRequestRule"]]:
+) -> Optional[Union[Error, list["TCPRequestRule"]]]:
     """Return an array of all TCP Request Rules
 
      Returns all TCP Request Rules that are configured in specified parent and parent type.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPRequestRule']
+        Union[Error, list['TCPRequestRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/get_tcp_request_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/get_tcp_request_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPRequestRule]]:
+) -> Union[Error, TCPRequestRule]:
     if response.status_code == 200:
         response_200 = TCPRequestRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/get_tcp_request_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/get_tcp_request_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPRequestRule]]:
+) -> Union[Error, TCPRequestRule]:
     if response.status_code == 200:
         response_200 = TCPRequestRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/get_tcp_request_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/get_tcp_request_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPRequestRule]]:
+) -> Union[Error, TCPRequestRule]:
     if response.status_code == 200:
         response_200 = TCPRequestRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/replace_all_tcp_request_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/replace_all_tcp_request_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemastcp_request_rules_item_data in body:
         componentsschemastcp_request_rules_item = componentsschemastcp_request_rules_item_data.to_dict()
-        _body.append(componentsschemastcp_request_rules_item)
+        _kwargs["json"].append(componentsschemastcp_request_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["TCPRequestRule"]]]:
+) -> Union[Error, list["TCPRequestRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemastcp_request_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemastcp_request_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/replace_all_tcp_request_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/replace_all_tcp_request_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemastcp_request_rules_item_data in body:
         componentsschemastcp_request_rules_item = componentsschemastcp_request_rules_item_data.to_dict()
-        _body.append(componentsschemastcp_request_rules_item)
+        _kwargs["json"].append(componentsschemastcp_request_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["TCPRequestRule"]]]:
+) -> Union[Error, list["TCPRequestRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemastcp_request_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemastcp_request_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/replace_all_tcp_request_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/replace_all_tcp_request_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemastcp_request_rules_item_data in body:
         componentsschemastcp_request_rules_item = componentsschemastcp_request_rules_item_data.to_dict()
-        _body.append(componentsschemastcp_request_rules_item)
+        _kwargs["json"].append(componentsschemastcp_request_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["TCPRequestRule"]]]:
+) -> Union[Error, list["TCPRequestRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemastcp_request_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemastcp_request_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/replace_tcp_request_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/replace_tcp_request_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPRequestRule]]:
+) -> Union[Error, TCPRequestRule]:
     if response.status_code == 200:
         response_200 = TCPRequestRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = TCPRequestRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/replace_tcp_request_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/replace_tcp_request_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPRequestRule]]:
+) -> Union[Error, TCPRequestRule]:
     if response.status_code == 200:
         response_200 = TCPRequestRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = TCPRequestRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/replace_tcp_request_rule_frontend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_request_rule/replace_tcp_request_rule_frontend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_request_rule import TCPRequestRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPRequestRule]]:
+) -> Union[Error, TCPRequestRule]:
     if response.status_code == 200:
         response_200 = TCPRequestRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = TCPRequestRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/create_tcp_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/create_tcp_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_response_rule import TCPResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPResponseRule]]:
+) -> Union[Error, TCPResponseRule]:
     if response.status_code == 201:
         response_201 = TCPResponseRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = TCPResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/create_tcp_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/create_tcp_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_response_rule import TCPResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPResponseRule]]:
+) -> Union[Error, TCPResponseRule]:
     if response.status_code == 201:
         response_201 = TCPResponseRule.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = TCPResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/delete_tcp_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/delete_tcp_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/delete_tcp_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/delete_tcp_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -36,23 +35,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/get_all_tcp_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/get_all_tcp_response_rule_backend.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.tcp_response_rule import TCPResponseRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["TCPResponseRule"]]:
+) -> Union[Error, list["TCPResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemastcp_response_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["TCPResponseRule"]]:
+) -> Response[Union[Error, list["TCPResponseRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPResponseRule"]]:
+) -> Response[Union[Error, list["TCPResponseRule"]]]:
     """Return an array of all TCP Response Rules
 
      Returns all TCP Response Rules that are configured in specified backend.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPResponseRule']]
+        Response[Union[Error, list['TCPResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPResponseRule"]]:
+) -> Optional[Union[Error, list["TCPResponseRule"]]]:
     """Return an array of all TCP Response Rules
 
      Returns all TCP Response Rules that are configured in specified backend.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPResponseRule']
+        Union[Error, list['TCPResponseRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPResponseRule"]]:
+) -> Response[Union[Error, list["TCPResponseRule"]]]:
     """Return an array of all TCP Response Rules
 
      Returns all TCP Response Rules that are configured in specified backend.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPResponseRule']]
+        Response[Union[Error, list['TCPResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPResponseRule"]]:
+) -> Optional[Union[Error, list["TCPResponseRule"]]]:
     """Return an array of all TCP Response Rules
 
      Returns all TCP Response Rules that are configured in specified backend.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPResponseRule']
+        Union[Error, list['TCPResponseRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/get_all_tcp_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/get_all_tcp_response_rule_defaults.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.tcp_response_rule import TCPResponseRule
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["TCPResponseRule"]]:
+) -> Union[Error, list["TCPResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemastcp_response_rules_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["TCPResponseRule"]]:
+) -> Response[Union[Error, list["TCPResponseRule"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPResponseRule"]]:
+) -> Response[Union[Error, list["TCPResponseRule"]]]:
     """Return an array of all TCP Response Rules
 
      Returns all TCP Response Rules that are configured in specified backend.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPResponseRule']]
+        Response[Union[Error, list['TCPResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPResponseRule"]]:
+) -> Optional[Union[Error, list["TCPResponseRule"]]]:
     """Return an array of all TCP Response Rules
 
      Returns all TCP Response Rules that are configured in specified backend.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPResponseRule']
+        Union[Error, list['TCPResponseRule']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["TCPResponseRule"]]:
+) -> Response[Union[Error, list["TCPResponseRule"]]]:
     """Return an array of all TCP Response Rules
 
      Returns all TCP Response Rules that are configured in specified backend.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['TCPResponseRule']]
+        Response[Union[Error, list['TCPResponseRule']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["TCPResponseRule"]]:
+) -> Optional[Union[Error, list["TCPResponseRule"]]]:
     """Return an array of all TCP Response Rules
 
      Returns all TCP Response Rules that are configured in specified backend.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['TCPResponseRule']
+        Union[Error, list['TCPResponseRule']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/get_tcp_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/get_tcp_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_response_rule import TCPResponseRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPResponseRule]]:
+) -> Union[Error, TCPResponseRule]:
     if response.status_code == 200:
         response_200 = TCPResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/get_tcp_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/get_tcp_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_response_rule import TCPResponseRule
@@ -33,19 +32,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPResponseRule]]:
+) -> Union[Error, TCPResponseRule]:
     if response.status_code == 200:
         response_200 = TCPResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/replace_all_tcp_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/replace_all_tcp_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_response_rule import TCPResponseRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemastcp_response_rules_item_data in body:
         componentsschemastcp_response_rules_item = componentsschemastcp_response_rules_item_data.to_dict()
-        _body.append(componentsschemastcp_response_rules_item)
+        _kwargs["json"].append(componentsschemastcp_response_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["TCPResponseRule"]]]:
+) -> Union[Error, list["TCPResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemastcp_response_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemastcp_response_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/replace_all_tcp_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/replace_all_tcp_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_response_rule import TCPResponseRule
@@ -36,12 +35,11 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = []
+    _kwargs["json"] = []
     for componentsschemastcp_response_rules_item_data in body:
         componentsschemastcp_response_rules_item = componentsschemastcp_response_rules_item_data.to_dict()
-        _body.append(componentsschemastcp_response_rules_item)
+        _kwargs["json"].append(componentsschemastcp_response_rules_item)
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -50,7 +48,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, list["TCPResponseRule"]]]:
+) -> Union[Error, list["TCPResponseRule"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -62,6 +60,7 @@ def _parse_response(
             response_200.append(componentsschemastcp_response_rules_item)
 
         return response_200
+
     if response.status_code == 202:
         response_202 = []
         _response_202 = response.json()
@@ -73,14 +72,15 @@ def _parse_response(
             response_202.append(componentsschemastcp_response_rules_item)
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/replace_tcp_response_rule_backend.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/replace_tcp_response_rule_backend.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_response_rule import TCPResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPResponseRule]]:
+) -> Union[Error, TCPResponseRule]:
     if response.status_code == 200:
         response_200 = TCPResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = TCPResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/replace_tcp_response_rule_defaults.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/tcp_response_rule/replace_tcp_response_rule_defaults.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.tcp_response_rule import TCPResponseRule
@@ -37,9 +36,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -48,27 +46,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TCPResponseRule]]:
+) -> Union[Error, TCPResponseRule]:
     if response.status_code == 200:
         response_200 = TCPResponseRule.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = TCPResponseRule.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/traces/create_trace_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/traces/create_trace_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.trace_event import TraceEvent
@@ -35,9 +34,8 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
@@ -46,27 +44,30 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, TraceEvent]]:
+) -> Union[Error, TraceEvent]:
     if response.status_code == 201:
         response_201 = TraceEvent.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = TraceEvent.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/traces/create_traces.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/traces/create_traces.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.traces import Traces
@@ -35,38 +34,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Traces]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Traces]:
     if response.status_code == 201:
         response_201 = Traces.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Traces.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/traces/delete_trace_entry.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/traces/delete_trace_entry.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.trace_event import TraceEvent
@@ -35,32 +34,31 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/traces/delete_traces.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/traces/delete_traces.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -34,23 +33,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/traces/get_traces.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/traces/get_traces.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.traces import Traces
@@ -32,21 +31,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Traces]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Traces]:
     if response.status_code == 200:
         response_200 = Traces.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/traces/replace_traces.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/traces/replace_traces.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.traces import Traces
@@ -38,38 +37,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Traces]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Traces]:
     if response.status_code == 200:
         response_200 = Traces.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = Traces.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/transactions/commit_transaction.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/transactions/commit_transaction.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.configuration_transaction import ConfigurationTransaction
 from ...models.error import Error
@@ -32,31 +31,35 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ConfigurationTransaction, Error]]:
+) -> Union[ConfigurationTransaction, Error]:
     if response.status_code == 200:
         response_200 = ConfigurationTransaction.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = ConfigurationTransaction.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
+
     if response.status_code == 406:
         response_406 = Error.from_dict(response.json())
 
         return response_406
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/transactions/delete_transaction.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/transactions/delete_transaction.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import Response
@@ -20,20 +19,19 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/transactions/get_transaction.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/transactions/get_transaction.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.configuration_transaction import ConfigurationTransaction
 from ...models.error import Error
@@ -23,19 +22,20 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ConfigurationTransaction, Error]]:
+) -> Union[ConfigurationTransaction, Error]:
     if response.status_code == 200:
         response_200 = ConfigurationTransaction.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/transactions/get_transactions.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/transactions/get_transactions.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.configuration_transaction import ConfigurationTransaction
+from ...models.error import Error
 from ...models.get_transactions_status import GetTransactionsStatus
 from ...types import UNSET, Response, Unset
 
@@ -35,7 +35,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["ConfigurationTransaction"]]:
+) -> Union[Error, list["ConfigurationTransaction"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -47,15 +47,15 @@ def _parse_response(
             response_200.append(componentsschemastransactions_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["ConfigurationTransaction"]]:
+) -> Response[Union[Error, list["ConfigurationTransaction"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -68,7 +68,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     status: Union[Unset, GetTransactionsStatus] = UNSET,
-) -> Response[list["ConfigurationTransaction"]]:
+) -> Response[Union[Error, list["ConfigurationTransaction"]]]:
     """Return list of HAProxy configuration transactions.
 
      Returns a list of HAProxy configuration transactions. Transactions can be filtered by their status.
@@ -81,7 +81,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ConfigurationTransaction']]
+        Response[Union[Error, list['ConfigurationTransaction']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     status: Union[Unset, GetTransactionsStatus] = UNSET,
-) -> Optional[list["ConfigurationTransaction"]]:
+) -> Optional[Union[Error, list["ConfigurationTransaction"]]]:
     """Return list of HAProxy configuration transactions.
 
      Returns a list of HAProxy configuration transactions. Transactions can be filtered by their status.
@@ -112,7 +112,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ConfigurationTransaction']
+        Union[Error, list['ConfigurationTransaction']]
     """
 
     return sync_detailed(
@@ -125,7 +125,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     status: Union[Unset, GetTransactionsStatus] = UNSET,
-) -> Response[list["ConfigurationTransaction"]]:
+) -> Response[Union[Error, list["ConfigurationTransaction"]]]:
     """Return list of HAProxy configuration transactions.
 
      Returns a list of HAProxy configuration transactions. Transactions can be filtered by their status.
@@ -138,7 +138,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['ConfigurationTransaction']]
+        Response[Union[Error, list['ConfigurationTransaction']]]
     """
 
     kwargs = _get_kwargs(
@@ -154,7 +154,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     status: Union[Unset, GetTransactionsStatus] = UNSET,
-) -> Optional[list["ConfigurationTransaction"]]:
+) -> Optional[Union[Error, list["ConfigurationTransaction"]]]:
     """Return list of HAProxy configuration transactions.
 
      Returns a list of HAProxy configuration transactions. Transactions can be filtered by their status.
@@ -167,7 +167,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['ConfigurationTransaction']
+        Union[Error, list['ConfigurationTransaction']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/transactions/start_transaction.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/transactions/start_transaction.py
@@ -3,9 +3,9 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.configuration_transaction import ConfigurationTransaction
+from ...models.error import Error
 from ...models.start_transaction_response_429 import StartTransactionResponse429
 from ...types import UNSET, Response
 
@@ -31,24 +31,25 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ConfigurationTransaction, StartTransactionResponse429]]:
+) -> Union[ConfigurationTransaction, Error, StartTransactionResponse429]:
     if response.status_code == 201:
         response_201 = ConfigurationTransaction.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 429:
         response_429 = StartTransactionResponse429.from_dict(response.json())
 
         return response_429
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[ConfigurationTransaction, StartTransactionResponse429]]:
+) -> Response[Union[ConfigurationTransaction, Error, StartTransactionResponse429]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -61,7 +62,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     version: int,
-) -> Response[Union[ConfigurationTransaction, StartTransactionResponse429]]:
+) -> Response[Union[ConfigurationTransaction, Error, StartTransactionResponse429]]:
     """Start a new transaction
 
      Starts a new transaction and returns it's id
@@ -74,7 +75,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[ConfigurationTransaction, StartTransactionResponse429]]
+        Response[Union[ConfigurationTransaction, Error, StartTransactionResponse429]]
     """
 
     kwargs = _get_kwargs(
@@ -92,7 +93,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     version: int,
-) -> Optional[Union[ConfigurationTransaction, StartTransactionResponse429]]:
+) -> Optional[Union[ConfigurationTransaction, Error, StartTransactionResponse429]]:
     """Start a new transaction
 
      Starts a new transaction and returns it's id
@@ -105,7 +106,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[ConfigurationTransaction, StartTransactionResponse429]
+        Union[ConfigurationTransaction, Error, StartTransactionResponse429]
     """
 
     return sync_detailed(
@@ -118,7 +119,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     version: int,
-) -> Response[Union[ConfigurationTransaction, StartTransactionResponse429]]:
+) -> Response[Union[ConfigurationTransaction, Error, StartTransactionResponse429]]:
     """Start a new transaction
 
      Starts a new transaction and returns it's id
@@ -131,7 +132,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[ConfigurationTransaction, StartTransactionResponse429]]
+        Response[Union[ConfigurationTransaction, Error, StartTransactionResponse429]]
     """
 
     kwargs = _get_kwargs(
@@ -147,7 +148,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     version: int,
-) -> Optional[Union[ConfigurationTransaction, StartTransactionResponse429]]:
+) -> Optional[Union[ConfigurationTransaction, Error, StartTransactionResponse429]]:
     """Start a new transaction
 
      Starts a new transaction and returns it's id
@@ -160,7 +161,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[ConfigurationTransaction, StartTransactionResponse429]
+        Union[ConfigurationTransaction, Error, StartTransactionResponse429]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/user/create_user.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/user/create_user.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.user import User
@@ -38,38 +37,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, User]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, User]:
     if response.status_code == 201:
         response_201 = User.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = User.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/user/delete_user.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/user/delete_user.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -38,23 +37,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/user/get_user.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/user/get_user.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.user import User
@@ -33,21 +32,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, User]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, User]:
     if response.status_code == 200:
         response_200 = User.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/user/get_users.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/user/get_users.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.user import User
 from ...types import UNSET, Response, Unset
 
@@ -31,7 +31,9 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[list["User"]]:
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Union[Error, list["User"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -41,13 +43,15 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
             response_200.append(componentsschemasusers_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[list["User"]]:
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Error, list["User"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -61,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     userlist: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["User"]]:
+) -> Response[Union[Error, list["User"]]]:
     """Return an array of userlist users
 
     Args:
@@ -73,7 +77,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['User']]
+        Response[Union[Error, list['User']]]
     """
 
     kwargs = _get_kwargs(
@@ -93,7 +97,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     userlist: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["User"]]:
+) -> Optional[Union[Error, list["User"]]]:
     """Return an array of userlist users
 
     Args:
@@ -105,7 +109,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['User']
+        Union[Error, list['User']]
     """
 
     return sync_detailed(
@@ -120,7 +124,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     userlist: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Response[list["User"]]:
+) -> Response[Union[Error, list["User"]]]:
     """Return an array of userlist users
 
     Args:
@@ -132,7 +136,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['User']]
+        Response[Union[Error, list['User']]]
     """
 
     kwargs = _get_kwargs(
@@ -150,7 +154,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     userlist: str,
     transaction_id: Union[Unset, str] = UNSET,
-) -> Optional[list["User"]]:
+) -> Optional[Union[Error, list["User"]]]:
     """Return an array of userlist users
 
     Args:
@@ -162,7 +166,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['User']
+        Union[Error, list['User']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/user/replace_user.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/user/replace_user.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.user import User
@@ -39,38 +38,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, User]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, User]:
     if response.status_code == 200:
         response_200 = User.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 202:
         response_202 = User.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/userlist/create_userlist.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/userlist/create_userlist.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.userlist import Userlist
@@ -38,38 +37,38 @@ def _get_kwargs(
         "params": params,
     }
 
-    _body = body.to_dict()
+    _kwargs["json"] = body.to_dict()
 
-    _kwargs["json"] = _body
     headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Userlist]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Userlist]:
     if response.status_code == 201:
         response_201 = Userlist.from_dict(response.json())
 
         return response_201
+
     if response.status_code == 202:
         response_202 = Userlist.from_dict(response.json())
 
         return response_202
+
     if response.status_code == 400:
         response_400 = Error.from_dict(response.json())
 
         return response_400
+
     if response.status_code == 409:
         response_409 = Error.from_dict(response.json())
 
         return response_409
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/userlist/delete_userlist.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/userlist/delete_userlist.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union, cast
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...types import UNSET, Response, Unset
@@ -35,23 +34,23 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, Error]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Any, Error]:
     if response.status_code == 202:
         response_202 = cast(Any, None)
         return response_202
+
     if response.status_code == 204:
         response_204 = cast(Any, None)
         return response_204
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/userlist/get_userlist.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/userlist/get_userlist.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.userlist import Userlist
@@ -33,21 +32,20 @@ def _get_kwargs(
     return _kwargs
 
 
-def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Error, Userlist]]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Union[Error, Userlist]:
     if response.status_code == 200:
         response_200 = Userlist.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 404:
         response_404 = Error.from_dict(response.json())
 
         return response_404
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/userlist/get_userlists.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/api/userlist/get_userlists.py
@@ -3,8 +3,8 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.error import Error
 from ...models.userlist import Userlist
 from ...types import UNSET, Response, Unset
 
@@ -33,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[list["Userlist"]]:
+) -> Union[Error, list["Userlist"]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -43,15 +43,15 @@ def _parse_response(
             response_200.append(componentsschemasuserlists_item)
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+
+    response_default = Error.from_dict(response.json())
+
+    return response_default
 
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[list["Userlist"]]:
+) -> Response[Union[Error, list["Userlist"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["Userlist"]]:
+) -> Response[Union[Error, list["Userlist"]]]:
     """Return an array of userlists
 
      Returns an array of all configured userlists.
@@ -79,7 +79,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Userlist']]
+        Response[Union[Error, list['Userlist']]]
     """
 
     kwargs = _get_kwargs(
@@ -99,7 +99,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["Userlist"]]:
+) -> Optional[Union[Error, list["Userlist"]]]:
     """Return an array of userlists
 
      Returns an array of all configured userlists.
@@ -113,7 +113,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Userlist']
+        Union[Error, list['Userlist']]
     """
 
     return sync_detailed(
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Response[list["Userlist"]]:
+) -> Response[Union[Error, list["Userlist"]]]:
     """Return an array of userlists
 
      Returns an array of all configured userlists.
@@ -142,7 +142,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[list['Userlist']]
+        Response[Union[Error, list['Userlist']]]
     """
 
     kwargs = _get_kwargs(
@@ -160,7 +160,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     transaction_id: Union[Unset, str] = UNSET,
     full_section: Union[Unset, bool] = False,
-) -> Optional[list["Userlist"]]:
+) -> Optional[Union[Error, list["Userlist"]]]:
     """Return an array of userlists
 
      Returns an array of all configured userlists.
@@ -174,7 +174,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        list['Userlist']
+        Union[Error, list['Userlist']]
     """
 
     return (

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/acl_lines.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/acl_lines.py
@@ -36,6 +36,7 @@ class ACLLines:
         value = self.value
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "acl_name": acl_name,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/add_ca_entry_body.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/add_ca_entry_body.py
@@ -5,6 +5,7 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from .. import types
 from ..types import File
 
 T = TypeVar("T", bound="AddCaEntryBody")
@@ -33,20 +34,15 @@ class AddCaEntryBody:
 
         return field_dict
 
-    def to_multipart(self) -> dict[str, Any]:
-        file_upload = self.file_upload.to_tuple()
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
 
-        field_dict: dict[str, Any] = {}
+        files.append(("file_upload", self.file_upload.to_tuple()))
+
         for prop_name, prop in self.additional_properties.items():
-            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
 
-        field_dict.update(
-            {
-                "file_upload": file_upload,
-            }
-        )
-
-        return field_dict
+        return files
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/backend_base.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/backend_base.py
@@ -647,6 +647,7 @@ class BackendBase:
         use_fcgi_app = self.use_fcgi_app
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "name": name,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/backend_switching_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/backend_switching_rule.py
@@ -40,6 +40,7 @@ class BackendSwitchingRule:
         metadata = self.metadata
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "name": name,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/bind_params.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/bind_params.py
@@ -416,6 +416,7 @@ class BindParams:
             verify = self.verify.value
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update({})
         if accept_netscaler_cip is not UNSET:
             field_dict["accept_netscaler_cip"] = accept_netscaler_cip

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/certificate_store.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/certificate_store.py
@@ -47,6 +47,7 @@ class CertificateStore:
         metadata = self.metadata
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "name": name,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/consul_server.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/consul_server.py
@@ -125,6 +125,7 @@ class ConsulServer:
         token = self.token
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "address": address,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_ca_file_body.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_ca_file_body.py
@@ -5,6 +5,7 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from .. import types
 from ..types import File
 
 T = TypeVar("T", bound="CreateCaFileBody")
@@ -33,20 +34,15 @@ class CreateCaFileBody:
 
         return field_dict
 
-    def to_multipart(self) -> dict[str, Any]:
-        file_upload = self.file_upload.to_tuple()
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
 
-        field_dict: dict[str, Any] = {}
+        files.append(("file_upload", self.file_upload.to_tuple()))
+
         for prop_name, prop in self.additional_properties.items():
-            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
 
-        field_dict.update(
-            {
-                "file_upload": file_upload,
-            }
-        )
-
-        return field_dict
+        return files
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_cert_body.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_cert_body.py
@@ -5,6 +5,7 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from .. import types
 from ..types import File
 
 T = TypeVar("T", bound="CreateCertBody")
@@ -33,20 +34,15 @@ class CreateCertBody:
 
         return field_dict
 
-    def to_multipart(self) -> dict[str, Any]:
-        file_upload = self.file_upload.to_tuple()
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
 
-        field_dict: dict[str, Any] = {}
+        files.append(("file_upload", self.file_upload.to_tuple()))
+
         for prop_name, prop in self.additional_properties.items():
-            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
 
-        field_dict.update(
-            {
-                "file_upload": file_upload,
-            }
-        )
-
-        return field_dict
+        return files
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_crl_body.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_crl_body.py
@@ -5,6 +5,7 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from .. import types
 from ..types import File
 
 T = TypeVar("T", bound="CreateCrlBody")
@@ -33,20 +34,15 @@ class CreateCrlBody:
 
         return field_dict
 
-    def to_multipart(self) -> dict[str, Any]:
-        file_upload = self.file_upload.to_tuple()
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
 
-        field_dict: dict[str, Any] = {}
+        files.append(("file_upload", self.file_upload.to_tuple()))
+
         for prop_name, prop in self.additional_properties.items():
-            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
 
-        field_dict.update(
-            {
-                "file_upload": file_upload,
-            }
-        )
-
-        return field_dict
+        return files
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_spoe_body.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_spoe_body.py
@@ -5,7 +5,8 @@ from typing import Any, TypeVar, Union
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, File, FileJsonType, Unset
+from .. import types
+from ..types import UNSET, File, FileTypes, Unset
 
 T = TypeVar("T", bound="CreateSpoeBody")
 
@@ -21,7 +22,7 @@ class CreateSpoeBody:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        file_upload: Union[Unset, FileJsonType] = UNSET
+        file_upload: Union[Unset, FileTypes] = UNSET
         if not isinstance(self.file_upload, Unset):
             file_upload = self.file_upload.to_tuple()
 
@@ -33,20 +34,16 @@ class CreateSpoeBody:
 
         return field_dict
 
-    def to_multipart(self) -> dict[str, Any]:
-        file_upload: Union[Unset, FileJsonType] = UNSET
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
+
         if not isinstance(self.file_upload, Unset):
-            file_upload = self.file_upload.to_tuple()
+            files.append(("file_upload", self.file_upload.to_tuple()))
 
-        field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
-            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
 
-        field_dict.update({})
-        if file_upload is not UNSET:
-            field_dict["file_upload"] = file_upload
-
-        return field_dict
+        return files
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_storage_general_file_body.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_storage_general_file_body.py
@@ -5,7 +5,8 @@ from typing import Any, TypeVar, Union
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, File, FileJsonType, Unset
+from .. import types
+from ..types import UNSET, File, FileTypes, Unset
 
 T = TypeVar("T", bound="CreateStorageGeneralFileBody")
 
@@ -21,7 +22,7 @@ class CreateStorageGeneralFileBody:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        file_upload: Union[Unset, FileJsonType] = UNSET
+        file_upload: Union[Unset, FileTypes] = UNSET
         if not isinstance(self.file_upload, Unset):
             file_upload = self.file_upload.to_tuple()
 
@@ -33,20 +34,16 @@ class CreateStorageGeneralFileBody:
 
         return field_dict
 
-    def to_multipart(self) -> dict[str, Any]:
-        file_upload: Union[Unset, FileJsonType] = UNSET
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
+
         if not isinstance(self.file_upload, Unset):
-            file_upload = self.file_upload.to_tuple()
+            files.append(("file_upload", self.file_upload.to_tuple()))
 
-        field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
-            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
 
-        field_dict.update({})
-        if file_upload is not UNSET:
-            field_dict["file_upload"] = file_upload
-
-        return field_dict
+        return files
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_storage_map_file_body.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_storage_map_file_body.py
@@ -5,7 +5,8 @@ from typing import Any, TypeVar, Union
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, File, FileJsonType, Unset
+from .. import types
+from ..types import UNSET, File, FileTypes, Unset
 
 T = TypeVar("T", bound="CreateStorageMapFileBody")
 
@@ -21,7 +22,7 @@ class CreateStorageMapFileBody:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        file_upload: Union[Unset, FileJsonType] = UNSET
+        file_upload: Union[Unset, FileTypes] = UNSET
         if not isinstance(self.file_upload, Unset):
             file_upload = self.file_upload.to_tuple()
 
@@ -33,20 +34,16 @@ class CreateStorageMapFileBody:
 
         return field_dict
 
-    def to_multipart(self) -> dict[str, Any]:
-        file_upload: Union[Unset, FileJsonType] = UNSET
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
+
         if not isinstance(self.file_upload, Unset):
-            file_upload = self.file_upload.to_tuple()
+            files.append(("file_upload", self.file_upload.to_tuple()))
 
-        field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
-            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
 
-        field_dict.update({})
-        if file_upload is not UNSET:
-            field_dict["file_upload"] = file_upload
-
-        return field_dict
+        return files
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_storage_ssl_certificate_body.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_storage_ssl_certificate_body.py
@@ -5,7 +5,8 @@ from typing import Any, TypeVar, Union
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, File, FileJsonType, Unset
+from .. import types
+from ..types import UNSET, File, FileTypes, Unset
 
 T = TypeVar("T", bound="CreateStorageSSLCertificateBody")
 
@@ -21,7 +22,7 @@ class CreateStorageSSLCertificateBody:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        file_upload: Union[Unset, FileJsonType] = UNSET
+        file_upload: Union[Unset, FileTypes] = UNSET
         if not isinstance(self.file_upload, Unset):
             file_upload = self.file_upload.to_tuple()
 
@@ -33,20 +34,16 @@ class CreateStorageSSLCertificateBody:
 
         return field_dict
 
-    def to_multipart(self) -> dict[str, Any]:
-        file_upload: Union[Unset, FileJsonType] = UNSET
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
+
         if not isinstance(self.file_upload, Unset):
-            file_upload = self.file_upload.to_tuple()
+            files.append(("file_upload", self.file_upload.to_tuple()))
 
-        field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
-            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
 
-        field_dict.update({})
-        if file_upload is not UNSET:
-            field_dict["file_upload"] = file_upload
-
-        return field_dict
+        return files
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_storage_ssl_crt_list_file_body.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/create_storage_ssl_crt_list_file_body.py
@@ -5,7 +5,8 @@ from typing import Any, TypeVar, Union
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, File, FileJsonType, Unset
+from .. import types
+from ..types import UNSET, File, FileTypes, Unset
 
 T = TypeVar("T", bound="CreateStorageSSLCrtListFileBody")
 
@@ -21,7 +22,7 @@ class CreateStorageSSLCrtListFileBody:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        file_upload: Union[Unset, FileJsonType] = UNSET
+        file_upload: Union[Unset, FileTypes] = UNSET
         if not isinstance(self.file_upload, Unset):
             file_upload = self.file_upload.to_tuple()
 
@@ -33,20 +34,16 @@ class CreateStorageSSLCrtListFileBody:
 
         return field_dict
 
-    def to_multipart(self) -> dict[str, Any]:
-        file_upload: Union[Unset, FileJsonType] = UNSET
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
+
         if not isinstance(self.file_upload, Unset):
-            file_upload = self.file_upload.to_tuple()
+            files.append(("file_upload", self.file_upload.to_tuple()))
 
-        field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
-            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
 
-        field_dict.update({})
-        if file_upload is not UNSET:
-            field_dict["file_upload"] = file_upload
-
-        return field_dict
+        return files
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/defaults_base.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/defaults_base.py
@@ -788,6 +788,7 @@ class DefaultsBase:
         unique_id_header = self.unique_id_header
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update({})
         if abortonclose is not UNSET:
             field_dict["abortonclose"] = abortonclose

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/filter_.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/filter_.py
@@ -105,6 +105,7 @@ class Filter:
         trace_rnd_parsing = self.trace_rnd_parsing
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "type": type_,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/frontend_base.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/frontend_base.py
@@ -482,6 +482,7 @@ class FrontendBase:
         unique_id_header = self.unique_id_header
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "name": name,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/global_base.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/global_base.py
@@ -464,6 +464,7 @@ class GlobalBase:
             wurfl_options = self.wurfl_options.to_dict()
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update({})
         if chroot is not UNSET:
             field_dict["chroot"] = chroot

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/http_after_response_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/http_after_response_rule.py
@@ -152,6 +152,7 @@ class HTTPAfterResponseRule:
         var_scope = self.var_scope
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "type": type_,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/http_error_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/http_error_rule.py
@@ -67,6 +67,7 @@ class HTTPErrorRule:
                 return_hdrs.append(return_hdrs_item)
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "status": status,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/http_errors_section.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/http_errors_section.py
@@ -41,6 +41,7 @@ class HttpErrorsSection:
         metadata = self.metadata
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "error_files": error_files,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/http_request_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/http_request_rule.py
@@ -375,6 +375,7 @@ class HTTPRequestRule:
             wait_time = self.wait_time
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "type": type_,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/http_response_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/http_response_rule.py
@@ -313,6 +313,7 @@ class HTTPResponseRule:
             wait_time = self.wait_time
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "type": type_,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/log_forward_1.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/log_forward_1.py
@@ -58,6 +58,7 @@ class LogForward1:
             timeout_client = self.timeout_client
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "name": name,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/log_target.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/log_target.py
@@ -78,6 +78,7 @@ class LogTarget:
         sample_size = self.sample_size
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update({})
         if address is not UNSET:
             field_dict["address"] = address

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/mailers_section_base.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/mailers_section_base.py
@@ -34,6 +34,7 @@ class MailersSectionBase:
             timeout = self.timeout
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "name": name,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/peer_section_base.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/peer_section_base.py
@@ -58,6 +58,7 @@ class PeerSectionBase:
         shards = self.shards
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "name": name,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/quic_initial.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/quic_initial.py
@@ -41,6 +41,7 @@ class QUICInitial:
         metadata = self.metadata
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "type": type_,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/replace_cert_body.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/replace_cert_body.py
@@ -5,6 +5,7 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from .. import types
 from ..types import File
 
 T = TypeVar("T", bound="ReplaceCertBody")
@@ -33,20 +34,15 @@ class ReplaceCertBody:
 
         return field_dict
 
-    def to_multipart(self) -> dict[str, Any]:
-        file_upload = self.file_upload.to_tuple()
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
 
-        field_dict: dict[str, Any] = {}
+        files.append(("file_upload", self.file_upload.to_tuple()))
+
         for prop_name, prop in self.additional_properties.items():
-            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
 
-        field_dict.update(
-            {
-                "file_upload": file_upload,
-            }
-        )
-
-        return field_dict
+        return files
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/replace_crl_body.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/replace_crl_body.py
@@ -5,6 +5,7 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from .. import types
 from ..types import File
 
 T = TypeVar("T", bound="ReplaceCrlBody")
@@ -33,20 +34,15 @@ class ReplaceCrlBody:
 
         return field_dict
 
-    def to_multipart(self) -> dict[str, Any]:
-        file_upload = self.file_upload.to_tuple()
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
 
-        field_dict: dict[str, Any] = {}
+        files.append(("file_upload", self.file_upload.to_tuple()))
+
         for prop_name, prop in self.additional_properties.items():
-            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
 
-        field_dict.update(
-            {
-                "file_upload": file_upload,
-            }
-        )
-
-        return field_dict
+        return files
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/replace_storage_general_file_body.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/replace_storage_general_file_body.py
@@ -5,7 +5,8 @@ from typing import Any, TypeVar, Union
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, File, FileJsonType, Unset
+from .. import types
+from ..types import UNSET, File, FileTypes, Unset
 
 T = TypeVar("T", bound="ReplaceStorageGeneralFileBody")
 
@@ -21,7 +22,7 @@ class ReplaceStorageGeneralFileBody:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        file_upload: Union[Unset, FileJsonType] = UNSET
+        file_upload: Union[Unset, FileTypes] = UNSET
         if not isinstance(self.file_upload, Unset):
             file_upload = self.file_upload.to_tuple()
 
@@ -33,20 +34,16 @@ class ReplaceStorageGeneralFileBody:
 
         return field_dict
 
-    def to_multipart(self) -> dict[str, Any]:
-        file_upload: Union[Unset, FileJsonType] = UNSET
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
+
         if not isinstance(self.file_upload, Unset):
-            file_upload = self.file_upload.to_tuple()
+            files.append(("file_upload", self.file_upload.to_tuple()))
 
-        field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
-            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
 
-        field_dict.update({})
-        if file_upload is not UNSET:
-            field_dict["file_upload"] = file_upload
-
-        return field_dict
+        return files
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/ring_base.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/ring_base.py
@@ -69,6 +69,7 @@ class RingBase:
             timeout_server = self.timeout_server
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "name": name,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/server.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/server.py
@@ -699,6 +699,7 @@ class Server:
             port = self.port
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "address": address,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/server_switching_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/server_switching_rule.py
@@ -40,6 +40,7 @@ class ServerSwitchingRule:
         metadata = self.metadata
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "target_server": target_server,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/server_template.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/server_template.py
@@ -703,6 +703,7 @@ class ServerTemplate:
             port = self.port
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "fqdn": fqdn,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/set_ca_file_body.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/set_ca_file_body.py
@@ -5,6 +5,7 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from .. import types
 from ..types import File
 
 T = TypeVar("T", bound="SetCaFileBody")
@@ -33,20 +34,15 @@ class SetCaFileBody:
 
         return field_dict
 
-    def to_multipart(self) -> dict[str, Any]:
-        file_upload = self.file_upload.to_tuple()
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
 
-        field_dict: dict[str, Any] = {}
+        files.append(("file_upload", self.file_upload.to_tuple()))
+
         for prop_name, prop in self.additional_properties.items():
-            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
 
-        field_dict.update(
-            {
-                "file_upload": file_upload,
-            }
-        )
-
-        return field_dict
+        return files
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/site.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/site.py
@@ -51,6 +51,7 @@ class Site:
             service = self.service.to_dict()
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "name": name,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/stick_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/stick_rule.py
@@ -50,6 +50,7 @@ class StickRule:
         table = self.table
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "pattern": pattern,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/tcp_request_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/tcp_request_rule.py
@@ -194,6 +194,7 @@ class TCPRequestRule:
         var_scope = self.var_scope
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "type": type_,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/tcp_response_rule.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/tcp_response_rule.py
@@ -143,6 +143,7 @@ class TCPResponseRule:
         var_scope = self.var_scope
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update(
             {
                 "type": type_,

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/traces.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/models/traces.py
@@ -35,6 +35,7 @@ class Traces:
         metadata = self.metadata
 
         field_dict: dict[str, Any] = {}
+
         field_dict.update({})
         if entries is not UNSET:
             field_dict["entries"] = entries

--- a/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/types.py
+++ b/codegen/haproxy_dataplane_v3/haproxy_dataplane_v3/types.py
@@ -1,8 +1,8 @@
 """Contains some shared types for properties"""
 
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 from http import HTTPStatus
-from typing import BinaryIO, Generic, Literal, Optional, TypeVar
+from typing import IO, BinaryIO, Generic, Literal, Optional, TypeVar, Union
 
 from attrs import define
 
@@ -14,7 +14,15 @@ class Unset:
 
 UNSET: Unset = Unset()
 
-FileJsonType = tuple[Optional[str], BinaryIO, Optional[str]]
+# The types that `httpx.Client(files=)` can accept, copied from that library.
+FileContent = Union[IO[bytes], bytes, str]
+FileTypes = Union[
+    # (filename, file (or bytes), content_type)
+    tuple[Optional[str], FileContent, Optional[str]],
+    # (filename, file (or bytes), content_type, headers)
+    tuple[Optional[str], FileContent, Optional[str], Mapping[str, str]],
+]
+RequestFiles = list[tuple[str, FileTypes]]
 
 
 @define
@@ -25,7 +33,7 @@ class File:
     file_name: Optional[str] = None
     mime_type: Optional[str] = None
 
-    def to_tuple(self) -> FileJsonType:
+    def to_tuple(self) -> FileTypes:
         """Return a tuple representation that httpx will accept for multipart/form-data"""
         return self.file_name, self.payload, self.mime_type
 
@@ -43,4 +51,4 @@ class Response(Generic[T]):
     parsed: Optional[T]
 
 
-__all__ = ["UNSET", "File", "FileJsonType", "Response", "Unset"]
+__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/codegen/haproxy_dataplane_v3/pyproject.toml
+++ b/codegen/haproxy_dataplane_v3/pyproject.toml
@@ -5,19 +5,18 @@ description = "A client library for accessing HAProxy Data Plane API"
 authors = []
 readme = "README.md"
 packages = [
-    {include = "ha_proxy_data_plane_api_client"},
+    { include = "ha_proxy_data_plane_api_client" },
 ]
 include = ["CHANGELOG.md", "ha_proxy_data_plane_api_client/py.typed"]
 
-
 [tool.poetry.dependencies]
 python = "^3.9"
-httpx = ">=0.20.0,<0.29.0"
+httpx = ">=0.23.0,<0.29.0"
 attrs = ">=22.2.0"
 python-dateutil = "^2.8.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]

--- a/deploy/base/configmap.yaml
+++ b/deploy/base/configmap.yaml
@@ -92,7 +92,7 @@ data:
           {# Generate backend server entries from EndpointSlice using indexed lookup #}
           {# This demonstrates O(1) lookup using custom indexing by service name #}
           {% for endpoint_slice in resources.get('endpoints', {}).get_indexed(service_name) %}
-            {% for endpoint in endpoint_slice.endpoints %}
+            {% for endpoint in endpoint_slice.get('endpoints', []) %}
               {% for address in endpoint.addresses %}
           server {{ endpoint.targetRef.name }} {{ address }}:{{ port }}
               {% endfor %}

--- a/deploy/base/configmap.yaml
+++ b/deploy/base/configmap.yaml
@@ -92,7 +92,7 @@ data:
           {# Generate backend server entries from EndpointSlice using indexed lookup #}
           {# This demonstrates O(1) lookup using custom indexing by service name #}
           {% for endpoint_slice in resources.get('endpoints', {}).get_indexed(service_name) %}
-            {% for endpoint in endpoint_slice.get('endpoints', []) %}
+            {% for endpoint in endpoint_slice.get('endpoints') | default([], true) %}
               {% for address in endpoint.addresses %}
           server {{ endpoint.targetRef.name }} {{ address }}:{{ port }}
               {% endfor %}

--- a/example-configmap.yaml
+++ b/example-configmap.yaml
@@ -89,7 +89,7 @@ data:
           {# Generate backend server entries from EndpointSlice using indexed lookup #}
           {# This demonstrates O(1) lookup using custom indexing by service name #}
           {% for endpoint_slice in resources.get('endpoints', {}).get_indexed(service_name) %}
-            {% for endpoint in endpoint_slice.endpoints %}
+            {% for endpoint in endpoint_slice.get('endpoints', []) %}
               {% for address in endpoint.addresses %}
           server {{ service_name }}_{{ loop.index }} {{ address }}:{{ port }}
               {% endfor %}

--- a/example-configmap.yaml
+++ b/example-configmap.yaml
@@ -89,7 +89,7 @@ data:
           {# Generate backend server entries from EndpointSlice using indexed lookup #}
           {# This demonstrates O(1) lookup using custom indexing by service name #}
           {% for endpoint_slice in resources.get('endpoints', {}).get_indexed(service_name) %}
-            {% for endpoint in endpoint_slice.get('endpoints', []) %}
+            {% for endpoint in endpoint_slice.get('endpoints') | default([], true) %}
               {% for address in endpoint.addresses %}
           server {{ service_name }}_{{ loop.index }} {{ address }}:{{ port }}
               {% endfor %}

--- a/haproxy_template_ic/dataplane.py
+++ b/haproxy_template_ic/dataplane.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple
 from urllib.parse import urlparse, urlunparse
 
 import httpx
+import xxhash
 
 if TYPE_CHECKING:
     from haproxy_template_ic.config_models import IndexedResourceCollection
@@ -77,6 +78,11 @@ from haproxy_dataplane_v3.api.storage import (
     create_storage_general_file,
     delete_storage_general_file,
     replace_storage_general_file,
+    replace_storage_map_file,
+    replace_storage_ssl_certificate,
+    get_one_storage_map,
+    get_one_storage_ssl_certificate,
+    get_one_storage_general_file,
 )
 from haproxy_dataplane_v3.models.create_storage_map_file_body import (
     CreateStorageMapFileBody,
@@ -94,6 +100,41 @@ from haproxy_dataplane_v3.types import File
 from haproxy_dataplane_v3 import errors
 
 logger = logging.getLogger(__name__)
+
+
+def compute_content_hash(content: str) -> str:
+    """Compute xxHash64 of content for fast change detection.
+
+    Uses xxHash64 for its excellent performance (5GB/s+) and sufficient
+    collision resistance for non-cryptographic change detection.
+
+    Args:
+        content: The text content to hash
+
+    Returns:
+        Hash string in format "xxh64:<hex_hash>"
+    """
+    return f"xxh64:{xxhash.xxh64(content.encode('utf-8')).hexdigest()}"
+
+
+def extract_hash_from_description(description: Optional[str]) -> Optional[str]:
+    """Extract content hash from description field if present.
+
+    Args:
+        description: Description field that may contain a hash
+
+    Returns:
+        The hash string if found (e.g., "xxh64:abc123..."), None otherwise
+    """
+    if not description or not isinstance(description, str):
+        return None
+
+    # Check if description starts with a known hash format
+    if description.startswith(("xxh64:", "sha256:", "md5:")):
+        # Return just the hash part (before any additional description)
+        return description.split(" ", 1)[0]
+
+    return None
 
 
 def parse_haproxy_error_line(error_message: str) -> Optional[int]:
@@ -608,7 +649,7 @@ class DataplaneClient:
                     ) from e
 
     async def deploy_configuration(self, config_content: str) -> str:
-        """Deploy HAProxy configuration and reload.
+        """Deploy HAProxy configuration.
 
         Uses direct httpx calls since openapi-python-client doesn't support
         text/plain content type for configuration endpoints.
@@ -649,7 +690,6 @@ class DataplaneClient:
                             headers={"Content-Type": "text/plain"},
                             params={
                                 "version": str(current_version),
-                                "force_reload": "true",
                             },
                             auth=(self.auth[0], self.auth[1]),
                         )
@@ -719,202 +759,262 @@ class DataplaneClient:
                     original_error=e,
                 ) from e
 
-    async def sync_maps(self, maps: Dict[str, str]) -> None:
-        """Synchronize HAProxy map files to storage."""
+    def _extract_storage_content(self, storage_item: Optional[Any]) -> Optional[str]:
+        """Extract content from HAProxy storage API response.
 
+        Args:
+            storage_item: Response from get_one_storage_* API calls
+
+        Returns:
+            Decoded content string or None if extraction fails
+        """
+        if not storage_item or not hasattr(storage_item, "payload"):
+            return None
+        try:
+            content = storage_item.payload.read()
+            if hasattr(storage_item.payload, "seek"):
+                storage_item.payload.seek(0)
+            return content.decode("utf-8")
+        except Exception:
+            return None
+
+    async def _sync_storage_resources(
+        self,
+        resource_type: str,
+        new_resources: Dict[str, str],
+        get_all_func,
+        get_one_func,
+        create_func,
+        delete_func,
+        create_body_class,
+        mime_type: str = "text/plain",
+        replace_func=None,
+    ) -> None:
+        """Generic method to sync storage resources with content comparison.
+
+        Args:
+            resource_type: Type of resource ("map", "certificate", or "file")
+            new_resources: Dict of resource name to content
+            get_all_func: Async function to get all existing resources
+            get_one_func: Async function to get a single resource
+            create_func: Async function to create a resource
+            delete_func: Async function to delete a resource
+            create_body_class: Class to create request body
+            mime_type: MIME type for the resource
+            replace_func: Optional async function to replace resource content
+        """
         metrics = get_metrics_collector()
+        operation = f"sync_{resource_type}s"
 
-        with metrics.time_dataplane_api_operation("sync_maps"):
+        with metrics.time_dataplane_api_operation(operation):
             client = self._get_client()
 
             try:
-                # Get existing maps and create lookup dict
-                existing_maps = await get_all_storage_map_files.asyncio(client=client)
-                if existing_maps is None:
-                    existing_maps = []
+                # Get existing resources
+                existing = await get_all_func(client=client)
                 existing_dict = {
-                    f.storage_name: f for f in existing_maps if f.storage_name
+                    f.storage_name: f for f in (existing or []) if f.storage_name
                 }
 
-                target_names = set(maps.keys())
+                target_names = set(new_resources.keys())
                 existing_names = set(existing_dict.keys())
 
-                # Create new maps
+                created_count = 0
+                updated_count = 0
+                skipped_count = 0
+
+                # Create new resources
                 for name in target_names - existing_names:
-                    content = maps[name]
-                    body = CreateStorageMapFileBody(
+                    body = create_body_class(
                         file_upload=File(
-                            payload=io.BytesIO(content.encode("utf-8")),
+                            payload=io.BytesIO(new_resources[name].encode("utf-8")),
                             file_name=name,
-                            mime_type="text/plain",
+                            mime_type=mime_type,
                         )
                     )
-                    await create_storage_map_file.asyncio(client=client, body=body)
-                    logger.debug(f"🗺️ Created map {name}")
+                    body["description"] = compute_content_hash(new_resources[name])
+                    await create_func(client=client, body=body)
+                    created_count += 1
+                    logger.debug(f"Created {resource_type} {name}")
 
-                # Update changed maps (always update - no hash comparison available)
+                # Update or skip existing resources
                 for name in target_names & existing_names:
-                    content = maps[name]
-                    # For updates, we delete and recreate since replace isn't available
-                    await delete_storage_map.asyncio(client=client, name=name)
-                    body = CreateStorageMapFileBody(
-                        file_upload=File(
-                            payload=io.BytesIO(content.encode("utf-8")),
-                            file_name=name,
-                            mime_type="text/plain",
+                    new_content = new_resources[name]
+
+                    # Check if content changed
+                    try:
+                        existing_resource = await get_one_func(client=client, name=name)
+                        existing_content = self._extract_storage_content(
+                            existing_resource
                         )
-                    )
-                    await create_storage_map_file.asyncio(client=client, body=body)
-                    logger.debug(f"🔄 Updated map {name}")
 
-                # Delete obsolete maps
+                        if existing_content == new_content:
+                            skipped_count += 1
+                            logger.debug(f"Skipped {resource_type} {name} (unchanged)")
+                            continue
+                    except Exception as e:
+                        logger.debug(f"Could not fetch {resource_type} {name}: {e}")
+
+                    # Content changed - use replace if available, otherwise delete+create
+                    if replace_func:
+                        # Use generated replace function for maps/certificates
+                        # The generated functions expect: client, name, body (string content)
+                        await replace_func(client=client, name=name, body=new_content)
+                    else:
+                        # Fallback to delete+create (shouldn't happen with proper replace_func)
+                        await delete_func(client=client, name=name)
+                        body = create_body_class(
+                            file_upload=File(
+                                payload=io.BytesIO(new_content.encode("utf-8")),
+                                file_name=name,
+                                mime_type=mime_type,
+                            )
+                        )
+                        body["description"] = compute_content_hash(new_content)
+                        await create_func(client=client, body=body)
+
+                    updated_count += 1
+                    logger.debug(f"Updated {resource_type} {name}")
+
+                # Delete obsolete resources
                 for name in existing_names - target_names:
-                    await delete_storage_map.asyncio(client=client, name=name)
-                    logger.debug(f"🗑️ Deleted map {name}")
+                    await delete_func(client=client, name=name)
+                    logger.debug(f"Deleted {resource_type} {name}")
 
-                # Record successful sync
-                metrics.record_dataplane_api_request("sync_maps", "success")
+                # Log summary
+                if created_count or updated_count or skipped_count:
+                    logger.info(
+                        f"{resource_type.capitalize()}s: "
+                        f"{created_count} created, {updated_count} updated, {skipped_count} unchanged"
+                    )
+
+                metrics.record_dataplane_api_request(operation, "success")
 
             except Exception as e:
-                metrics.record_dataplane_api_request("sync_maps", "error")
+                metrics.record_dataplane_api_request(operation, "error")
                 raise DataplaneAPIError(
-                    f"Map sync failed: {e}", operation="sync_maps"
+                    f"{resource_type.capitalize()} sync failed: {e}",
+                    operation=operation,
                 ) from e
+
+    async def sync_maps(self, maps: Dict[str, str]) -> None:
+        """Synchronize HAProxy map files to storage."""
+        await self._sync_storage_resources(
+            resource_type="map",
+            new_resources=maps,
+            get_all_func=get_all_storage_map_files.asyncio,
+            get_one_func=get_one_storage_map.asyncio,
+            create_func=create_storage_map_file.asyncio,
+            delete_func=delete_storage_map.asyncio,
+            create_body_class=CreateStorageMapFileBody,
+            mime_type="text/plain",
+            replace_func=replace_storage_map_file.asyncio,
+        )
 
     async def sync_certificates(self, certificates: Dict[str, str]) -> None:
         """Synchronize SSL certificates to storage."""
-
-        metrics = get_metrics_collector()
-
-        with metrics.time_dataplane_api_operation("sync_certificates"):
-            client = self._get_client()
-
-            try:
-                # Get existing SSL certs and create lookup dict
-                existing_certs = await get_all_storage_ssl_certificates.asyncio(
-                    client=client
-                )
-                if existing_certs is None:
-                    existing_certs = []
-                existing_dict = {
-                    f.storage_name: f for f in existing_certs if f.storage_name
-                }
-
-                target_names = set(certificates.keys())
-                existing_names = set(existing_dict.keys())
-
-                # Create new certificates
-                for name in target_names - existing_names:
-                    content = certificates[name]
-                    body = CreateStorageSSLCertificateBody(
-                        file_upload=File(
-                            payload=io.BytesIO(content.encode("utf-8")),
-                            file_name=name,
-                            mime_type="application/x-pem-file",
-                        )
-                    )
-                    await create_storage_ssl_certificate.asyncio(
-                        client=client, body=body
-                    )
-                    logger.debug(f"🔐 Created certificate {name}")
-
-                # Update changed certificates (always update - no hash comparison available)
-                for name in target_names & existing_names:
-                    content = certificates[name]
-                    # For updates, we delete and recreate since replace isn't available
-                    await delete_storage_ssl_certificate.asyncio(
-                        client=client, name=name
-                    )
-                    body = CreateStorageSSLCertificateBody(
-                        file_upload=File(
-                            payload=io.BytesIO(content.encode("utf-8")),
-                            file_name=name,
-                            mime_type="application/x-pem-file",
-                        )
-                    )
-                    await create_storage_ssl_certificate.asyncio(
-                        client=client, body=body
-                    )
-                    logger.debug(f"🔄 Updated certificate {name}")
-
-                # Delete obsolete certificates
-                for name in existing_names - target_names:
-                    await delete_storage_ssl_certificate.asyncio(
-                        client=client, name=name
-                    )
-                    logger.debug(f"🗑️ Deleted certificate {name}")
-
-                # Record successful sync
-                metrics.record_dataplane_api_request("sync_certificates", "success")
-
-            except Exception as e:
-                metrics.record_dataplane_api_request("sync_certificates", "error")
-                raise DataplaneAPIError(
-                    f"Certificate sync failed: {e}", operation="sync_certificates"
-                ) from e
+        await self._sync_storage_resources(
+            resource_type="certificate",
+            new_resources=certificates,
+            get_all_func=get_all_storage_ssl_certificates.asyncio,
+            get_one_func=get_one_storage_ssl_certificate.asyncio,
+            create_func=create_storage_ssl_certificate.asyncio,
+            delete_func=delete_storage_ssl_certificate.asyncio,
+            create_body_class=CreateStorageSSLCertificateBody,
+            mime_type="application/x-pem-file",
+            replace_func=replace_storage_ssl_certificate.asyncio,
+        )
 
     async def sync_files(self, files: Dict[str, str]) -> None:
-        """Synchronize general-purpose files to HAProxy storage."""
+        """Synchronize general-purpose files to HAProxy storage.
 
+        Note: Files use replace instead of delete+create for updates.
+        """
         metrics = get_metrics_collector()
+        operation = "sync_files"
 
-        with metrics.time_dataplane_api_operation("sync_files"):
+        with metrics.time_dataplane_api_operation(operation):
             client = self._get_client()
 
             try:
-                # Get existing general files and create lookup dict
-                existing_files = await get_all_storage_general_files.asyncio(
-                    client=client
-                )
-                if existing_files is None:
-                    existing_files = []
+                # Get existing resources
+                existing = await get_all_storage_general_files.asyncio(client=client)
                 existing_dict = {
-                    f.storage_name: f for f in existing_files if f.storage_name
+                    f.storage_name: f for f in (existing or []) if f.storage_name
                 }
 
                 target_names = set(files.keys())
                 existing_names = set(existing_dict.keys())
 
+                created_count = 0
+                updated_count = 0
+                skipped_count = 0
+
                 # Create new files
                 for name in target_names - existing_names:
-                    content = files[name]
                     body = CreateStorageGeneralFileBody(
                         file_upload=File(
-                            payload=io.BytesIO(content.encode("utf-8")),
+                            payload=io.BytesIO(files[name].encode("utf-8")),
                             file_name=name,
                             mime_type="text/plain",
                         )
                     )
+                    body["description"] = compute_content_hash(files[name])
                     await create_storage_general_file.asyncio(client=client, body=body)
-                    logger.debug(f"📄 Created file {name}")
+                    created_count += 1
+                    logger.debug(f"Created file {name}")
 
-                # Update changed files (always update - no hash comparison available)
+                # Update or skip existing files
                 for name in target_names & existing_names:
-                    content = files[name]
+                    new_content = files[name]
+
+                    # Check if content changed
+                    try:
+                        existing_file = await get_one_storage_general_file.asyncio(
+                            client=client, name=name
+                        )
+                        existing_content = self._extract_storage_content(existing_file)
+
+                        if existing_content == new_content:
+                            skipped_count += 1
+                            logger.debug(f"Skipped file {name} (unchanged)")
+                            continue
+                    except Exception as e:
+                        logger.debug(f"Could not fetch file {name}: {e}")
+
+                    # Content changed - use replace for files
                     body = ReplaceStorageGeneralFileBody(
                         file_upload=File(
-                            payload=io.BytesIO(content.encode("utf-8")),
+                            payload=io.BytesIO(new_content.encode("utf-8")),
                             file_name=name,
                             mime_type="text/plain",
                         )
                     )
+                    body["description"] = compute_content_hash(new_content)
                     await replace_storage_general_file.asyncio(
                         client=client, name=name, body=body
                     )
-                    logger.debug(f"📝 Updated file {name}")
+                    updated_count += 1
+                    logger.debug(f"Updated file {name}")
 
                 # Delete obsolete files
                 for name in existing_names - target_names:
                     await delete_storage_general_file.asyncio(client=client, name=name)
-                    logger.debug(f"🗑️ Deleted file {name}")
+                    logger.debug(f"Deleted file {name}")
 
-                # Record successful sync
-                metrics.record_dataplane_api_request("sync_files", "success")
+                # Log summary
+                if created_count or updated_count or skipped_count:
+                    logger.info(
+                        f"Files: "
+                        f"{created_count} created, {updated_count} updated, {skipped_count} unchanged"
+                    )
+
+                metrics.record_dataplane_api_request(operation, "success")
 
             except Exception as e:
-                metrics.record_dataplane_api_request("sync_files", "error")
+                metrics.record_dataplane_api_request(operation, "error")
                 raise DataplaneAPIError(
-                    f"File sync failed: {e}", operation="sync_files"
+                    f"File sync failed: {e}", operation=operation
                 ) from e
 
     async def get_current_configuration(self) -> Optional[str]:

--- a/haproxy_template_ic/operator.py
+++ b/haproxy_template_ic/operator.py
@@ -615,7 +615,9 @@ def _render_haproxy_config(
         with trace_template_render(CONTENT_TYPE_HAPROXY_CONFIG):
             with metrics.time_template_render(CONTENT_TYPE_HAPROXY_CONFIG):
                 rendered_content = memo.template_renderer.render(
-                    memo.config.haproxy_config.template, **template_vars
+                    memo.config.haproxy_config.template,
+                    template_name="haproxy_config",
+                    **template_vars,
                 )
 
         rendered_config = RenderedConfig(content=rendered_content)
@@ -631,7 +633,8 @@ def _render_haproxy_config(
         metrics.record_template_render(CONTENT_TYPE_HAPROXY_CONFIG, "error")
         metrics.record_error("template_render_failed", "operator")
         record_span_event("haproxy_config_render_failed", {"error": str(e)})
-        logger.error(f"❌ Failed to render HAProxy configuration template: {e}")
+        # The error message already includes detailed context from format_template_error
+        logger.error(f"❌ {e}")
 
 
 def _render_content_templates(
@@ -652,7 +655,9 @@ def _render_content_templates(
                 with trace_template_render(content_type, filename):
                     with metrics.time_template_render(content_type):
                         rendered_content_text = memo.template_renderer.render(
-                            template_config.template, **template_vars
+                            template_config.template,
+                            template_name=f"{content_type}/{filename}",
+                            **template_vars,
                         )
 
                 rendered_content = RenderedContent(
@@ -686,9 +691,8 @@ def _render_content_templates(
                     f"{content_type}_render_failed",
                     {"filename": filename, "error": str(e)},
                 )
-                logger.error(
-                    f"❌ Failed to render {content_type} template for {filename}: {e}"
-                )
+                # The error message already includes detailed context from format_template_error
+                logger.error(f"❌ {e}")
 
     return template_errors
 

--- a/haproxy_template_ic/templating.py
+++ b/haproxy_template_ic/templating.py
@@ -221,6 +221,169 @@ def _get_context_lines(
     return context_lines
 
 
+def _format_snippet_context(
+    snippet_name: Optional[str],
+    line_no: int,
+    lines: list[str],
+    line_idx: int,
+    is_error: bool = False,
+    is_include: bool = False,
+) -> list[str]:
+    """Format context for a snippet or include location.
+
+    Args:
+        snippet_name: Name of the snippet (if known)
+        line_no: Line number in the snippet/template
+        lines: Lines of content
+        line_idx: Zero-based line index
+        is_error: Whether this is the error location
+        is_include: Whether this is an include statement
+
+    Returns:
+        Formatted context lines with appropriate headers
+    """
+    context_parts: list[str] = []
+    context_lines = _get_context_lines(lines, line_idx, line_no)
+
+    if not context_lines:
+        return context_parts
+
+    # Build header based on context type
+    if snippet_name:
+        if is_error:
+            header = f"\n  ↓ Snippet '{snippet_name}' (error at line {line_no}):\n"
+        elif is_include:
+            header = f"\n  ↓ Snippet '{snippet_name}' (include at line {line_no}):\n"
+        else:
+            header = f"\n  ↓ Snippet '{snippet_name}' (line {line_no}):\n"
+    else:
+        if is_error:
+            header = f"\n  ↓ Error location (line {line_no}):\n"
+        elif is_include:
+            header = f"\n  ↓ Include at line {line_no}:\n"
+        else:
+            header = f"\n  Template context (line {line_no}):\n"
+
+    context_parts.append(header + "\n".join(context_lines))
+    return context_parts
+
+
+def _process_include_chain(
+    template_frames: list[dict[str, Any]],
+    template_content: Optional[str],
+    snippets: Optional[TemplateSnippetCollection],
+) -> list[str]:
+    """Process a chain of includes to build error context.
+
+    Args:
+        template_frames: List of traceback frames from templates
+        template_content: Main template content
+        snippets: Collection of template snippets
+
+    Returns:
+        List of formatted error context parts
+    """
+    error_parts = []
+    include_chain: list[dict[str, Any]] = []
+    current_content = template_content
+
+    for frame_idx in range(len(template_frames)):
+        frame_dict = template_frames[frame_idx]
+        frame_line_no: int = frame_dict["line"]
+        is_last = frame_idx == len(template_frames) - 1
+
+        # Get the content to analyze
+        content_to_analyze = current_content
+
+        # For intermediate frames, get content from the previous snippet
+        if (
+            frame_idx > 0
+            and include_chain
+            and include_chain[-1].get("next_snippet_name")
+        ):
+            prev_snippet_name = include_chain[-1]["next_snippet_name"]
+            if snippets and prev_snippet_name in snippets:
+                snippet = snippets[prev_snippet_name]
+                content_to_analyze = (
+                    snippet.template if hasattr(snippet, "template") else str(snippet)
+                )
+            else:
+                # Snippet not found
+                content_to_analyze = None
+
+        # Extract context and snippet name (with input validation)
+        if not isinstance(content_to_analyze, str):
+            content_to_analyze = str(content_to_analyze) if content_to_analyze else None
+        lines = content_to_analyze.split("\n") if content_to_analyze else []
+        line_idx = frame_line_no - 1
+
+        snippet_name_for_next = None
+        if 0 <= line_idx < len(lines) and not is_last:
+            # Try to extract the snippet name from include statement
+            snippet_name_for_next = _extract_snippet_name(lines[line_idx])
+
+        # Store frame info
+        include_chain.append(
+            {
+                "line_no": frame_line_no,
+                "content": content_to_analyze,
+                "is_last": is_last,
+                "next_snippet_name": snippet_name_for_next,
+                "frame_idx": frame_idx,
+            }
+        )
+
+        # Update current content for next iteration
+        current_content = content_to_analyze
+
+    # Now display the chain
+    for idx, chain_item in enumerate(include_chain):
+        if not chain_item["content"]:
+            # No content available for this frame
+            if idx > 0 and include_chain[idx - 1].get("next_snippet_name"):
+                snippet_name = include_chain[idx - 1]["next_snippet_name"]
+                error_parts.append(
+                    f"\n  ↓ Snippet '{snippet_name}' (not found in snippets collection)"
+                )
+            continue
+
+        lines = chain_item["content"].split("\n")
+        line_idx = chain_item["line_no"] - 1
+
+        if 0 <= line_idx < len(lines):
+            # Determine context type
+            is_error = chain_item["is_last"]
+            is_include = not is_error and idx < len(include_chain) - 1
+
+            # Get snippet name from previous item if available
+            snippet_name = None
+            if idx > 0 and include_chain[idx - 1].get("next_snippet_name"):
+                snippet_name = include_chain[idx - 1]["next_snippet_name"]
+
+            # Format the context
+            if idx == 0:
+                # Main template
+                context_lines = _get_context_lines(
+                    lines, line_idx, chain_item["line_no"]
+                )
+                if context_lines:
+                    header = f"\n  Main template (include at line {chain_item['line_no']}):\n"
+                    error_parts.append(header + "\n".join(context_lines))
+            else:
+                # Use helper to format snippet context
+                context = _format_snippet_context(
+                    snippet_name,
+                    chain_item["line_no"],
+                    lines,
+                    line_idx,
+                    is_error=is_error,
+                    is_include=is_include,
+                )
+                error_parts.extend(context)
+
+    return error_parts
+
+
 def format_template_error(
     e: Exception,
     template_name: str = "template",
@@ -240,13 +403,17 @@ def format_template_error(
     """
     error_parts = [f"Template '{template_name}' rendering failed"]
 
-    # Collect all template frames from traceback
+    # Collect all template frames from traceback (with early termination)
     template_frames: list[dict[str, Any]] = []
     exc_type, exc_value, tb = sys.exc_info()
 
+    # Performance optimization: limit traceback depth to avoid excessive processing
+    MAX_FRAMES = 10  # Reasonable limit for template nesting
+
     if tb:
-        # Traverse entire traceback to find all template frames
-        while tb:
+        # Traverse traceback to find template frames (with early termination)
+        frame_count = 0
+        while tb and frame_count < MAX_FRAMES:
             frame = tb.tb_frame
             # Jinja2 templates have special filenames
             if frame.f_code.co_filename and (
@@ -262,6 +429,7 @@ def format_template_error(
                     }
                 )
             tb = tb.tb_next
+            frame_count += 1
 
     # For syntax errors, use the lineno attribute only if we don't have frames
     if not template_frames and hasattr(e, "lineno") and e.lineno:
@@ -279,184 +447,21 @@ def format_template_error(
                 error_parts.append("\n\n  Error occurred through nested includes:")
                 error_parts.append(f"\n  Error: {str(e)}\n")
 
-                # Build the include chain
-                include_chain: list[dict[str, Any]] = []
-                current_content = template_content
-
-                for frame_idx in range(len(template_frames)):
-                    frame_dict = template_frames[frame_idx]
-                    frame_line_no: int = frame_dict["line"]
-                    is_last = frame_idx == len(template_frames) - 1
-
-                    # Get the content to analyze
-                    content_to_analyze = current_content
-
-                    # For intermediate frames, we need the content from the previous snippet
-                    if (
-                        frame_idx > 0
-                        and include_chain
-                        and include_chain[-1].get("next_snippet_name")
-                    ):
-                        prev_snippet_name = include_chain[-1]["next_snippet_name"]
-                        if snippets and prev_snippet_name in snippets:
-                            snippet = snippets[prev_snippet_name]
-                            content_to_analyze = (
-                                snippet.template
-                                if hasattr(snippet, "template")
-                                else str(snippet)
-                            )
-                        else:
-                            # Snippet not found - log this but continue
-                            content_to_analyze = None
-
-                    # Extract context and snippet name
-                    lines = content_to_analyze.split("\n") if content_to_analyze else []
-                    line_idx = frame_line_no - 1
-
-                    snippet_name_for_next = None
-                    if 0 <= line_idx < len(lines) and not is_last:
-                        # Try to extract the snippet name from include statement
-                        snippet_name_for_next = _extract_snippet_name(lines[line_idx])
-
-                    # Store frame info
-                    include_chain.append(
-                        {
-                            "line_no": frame_line_no,
-                            "content": content_to_analyze,
-                            "is_last": is_last,
-                            "next_snippet_name": snippet_name_for_next,
-                            "frame_idx": frame_idx,
-                        }
-                    )
-
-                    # Update current content for next iteration
-                    current_content = content_to_analyze
-
-                # Now display the chain
-                for idx, chain_item in enumerate(include_chain):
-                    if not chain_item["content"]:
-                        # No content available for this frame (e.g., missing snippet)
-                        if idx > 0 and include_chain[idx - 1].get("next_snippet_name"):
-                            snippet_name = include_chain[idx - 1]["next_snippet_name"]
-                            error_parts.append(
-                                f"\n  ↓ Snippet '{snippet_name}' (not found in snippets collection)"
-                            )
-                        continue
-
-                    lines = chain_item["content"].split("\n")
-                    line_idx = chain_item["line_no"] - 1
-
-                    if 0 <= line_idx < len(lines):
-                        # Show context
-                        line_number: int = chain_item["line_no"]
-                        context_lines = _get_context_lines(lines, line_idx, line_number)
-
-                        if context_lines:
-                            if idx == 0:
-                                # Main template
-                                error_parts.append(
-                                    f"\n  Main template (include at line {chain_item['line_no']}):\n"
-                                    + "\n".join(context_lines)
-                                )
-                            elif chain_item["is_last"]:
-                                # Error location - get the snippet name from previous item
-                                snippet_name = None
-                                if idx > 0 and include_chain[idx - 1].get(
-                                    "next_snippet_name"
-                                ):
-                                    snippet_name = include_chain[idx - 1][
-                                        "next_snippet_name"
-                                    ]
-
-                                if snippet_name:
-                                    error_parts.append(
-                                        f"\n  ↓ Snippet '{snippet_name}' (error at line {chain_item['line_no']}):\n"
-                                        + "\n".join(context_lines)
-                                    )
-                                else:
-                                    error_parts.append(
-                                        f"\n  ↓ Error location (line {chain_item['line_no']}):\n"
-                                        + "\n".join(context_lines)
-                                    )
-                            else:
-                                # Intermediate include - get snippet name from previous
-                                snippet_name = None
-                                if idx > 0 and include_chain[idx - 1].get(
-                                    "next_snippet_name"
-                                ):
-                                    snippet_name = include_chain[idx - 1][
-                                        "next_snippet_name"
-                                    ]
-
-                                if snippet_name:
-                                    error_parts.append(
-                                        f"\n  ↓ Snippet '{snippet_name}' (include at line {chain_item['line_no']}):\n"
-                                        + "\n".join(context_lines)
-                                    )
-                                else:
-                                    error_parts.append(
-                                        f"\n  ↓ Include at line {chain_item['line_no']}:\n"
-                                        + "\n".join(context_lines)
-                                    )
+                # Use helper to process include chain
+                chain_context = _process_include_chain(
+                    template_frames, template_content, snippets
+                )
+                error_parts.extend(chain_context)
             else:
-                # Simple two-level include (existing logic)
-                include_frame = template_frames[0]
-                error_frame = template_frames[-1]
-                include_line: int = include_frame["line"]
-                error_line: int = error_frame["line"]
+                # Simple two-level include
+                error_parts.append("\n\n  Error occurred in included snippet:")
+                error_parts.append(f"\n  Error: {str(e)}\n")
 
-                # Show main template context (include statement)
-                snippet_name = None
-                if template_content:
-                    lines = template_content.split("\n")
-                    line_idx = include_line - 1
-
-                    if 0 <= line_idx < len(lines):
-                        # Try to extract snippet name from include statement first
-                        snippet_name = _extract_snippet_name(lines[line_idx])
-
-                        # Show main template context
-                        context_lines = _get_context_lines(
-                            lines, line_idx, include_line
-                        )
-
-                        if context_lines:
-                            error_parts.append(
-                                "\n\n  Error occurred in included snippet:"
-                            )
-                            error_parts.append(f"\n  Error: {str(e)}\n")
-                            error_parts.append(
-                                "\n  Main template (include at line "
-                                + str(include_line)
-                                + "):\n"
-                                + "\n".join(context_lines)
-                            )
-
-                        # Show snippet context if we have the snippet
-                        if snippet_name and snippets and snippet_name in snippets:
-                            snippet = snippets[snippet_name]
-                            snippet_content = (
-                                snippet.template
-                                if hasattr(snippet, "template")
-                                else str(snippet)
-                            )
-                            snippet_lines = snippet_content.split("\n")
-
-                            # The error_line here is the line number within the snippet
-                            snippet_line_idx = error_line - 1
-
-                            if 0 <= snippet_line_idx < len(snippet_lines):
-                                snippet_context = _get_context_lines(
-                                    snippet_lines, snippet_line_idx, error_line
-                                )
-
-                                if snippet_context:
-                                    error_parts.append(
-                                        f"\n  Snippet '{snippet_name}' (error at line "
-                                        + str(error_line)
-                                        + "):\n"
-                                        + "\n".join(snippet_context)
-                                    )
+                # Use helper to process the simpler two-level case
+                chain_context = _process_include_chain(
+                    template_frames, template_content, snippets
+                )
+                error_parts.extend(chain_context)
         else:
             # Single frame - regular error
             line_no: int = template_frames[0]["line"]

--- a/haproxy_template_ic/templating.py
+++ b/haproxy_template_ic/templating.py
@@ -8,8 +8,9 @@ functionality including support for template snippets and custom filters.
 import base64
 import os
 import re
+import sys
 from functools import lru_cache
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Union, Union
 
 from pathvalidate import ValidationError, is_valid_filename, sanitize_filename
 
@@ -36,6 +37,17 @@ from .constants import (
     ERROR_TEMPLATE_SYNTAX,
     TEMPLATE_CACHE_SIZE,
 )
+
+# -----------------------------------------------------------------------------
+# Constants and patterns
+# -----------------------------------------------------------------------------
+
+# Regex pattern for extracting snippet names from include statements
+INCLUDE_PATTERN = re.compile(r'{%\s*include\s+["\']([^"\']+)["\']\s*%}')
+
+# Context lines to show around errors
+CONTEXT_LINES_BEFORE = 2
+CONTEXT_LINES_AFTER = 3
 
 # -----------------------------------------------------------------------------
 # Jinja2 setup and template functionality
@@ -158,6 +170,333 @@ class SnippetLoader(BaseLoader):
         # Get template content from snippet
         source = snippet.template if hasattr(snippet, "template") else str(snippet)
         return source, None, lambda: True
+
+
+def _extract_snippet_name(line_text: str) -> Optional[str]:
+    """Extract snippet name from an include statement.
+
+    Args:
+        line_text: Line of template text that may contain an include statement
+
+    Returns:
+        The snippet name if found, None otherwise
+    """
+    if "include" in line_text:
+        match = INCLUDE_PATTERN.search(line_text)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _get_context_lines(
+    lines: list[str],
+    line_idx: int,
+    error_line_no: int,
+    context_before: int = CONTEXT_LINES_BEFORE,
+    context_after: int = CONTEXT_LINES_AFTER,
+) -> list[str]:
+    """Get context lines around a specific line.
+
+    Args:
+        lines: List of lines from the template
+        line_idx: Zero-based index of the target line
+        error_line_no: One-based line number for display
+        context_before: Number of lines to show before
+        context_after: Number of lines to show after
+
+    Returns:
+        List of formatted context lines with line numbers and markers
+    """
+    if not lines or line_idx < 0 or line_idx >= len(lines):
+        return []
+
+    start = max(0, line_idx - context_before)
+    end = min(len(lines), line_idx + context_after + 1)
+
+    context_lines = []
+    for i in range(start, end):
+        prefix = ">>> " if i == line_idx else "    "
+        context_lines.append(f"  {i + 1:4d}: {prefix}{lines[i]}")
+
+    return context_lines
+
+
+def format_template_error(
+    e: Exception,
+    template_name: str = "template",
+    template_content: Optional[str] = None,
+    snippets: Optional[TemplateSnippetCollection] = None,
+) -> str:
+    """Format a template error with detailed context for debugging.
+
+    Args:
+        e: The exception that occurred
+        template_name: Name of the template that failed
+        template_content: Optional template content to show context
+        snippets: Optional collection of template snippets for resolving includes
+
+    Returns:
+        Formatted error message with context
+    """
+    error_parts = [f"Template '{template_name}' rendering failed"]
+
+    # Collect all template frames from traceback
+    template_frames: list[dict[str, Any]] = []
+    exc_type, exc_value, tb = sys.exc_info()
+
+    if tb:
+        # Traverse entire traceback to find all template frames
+        while tb:
+            frame = tb.tb_frame
+            # Jinja2 templates have special filenames
+            if frame.f_code.co_filename and (
+                "<template>" in frame.f_code.co_filename
+                or "memory:" in frame.f_code.co_filename
+            ):
+                # Store the frame's filename for snippet detection
+                template_frames.append(
+                    {
+                        "line": tb.tb_lineno,
+                        "frame": frame,
+                        "filename": frame.f_code.co_filename,
+                    }
+                )
+            tb = tb.tb_next
+
+    # For syntax errors, use the lineno attribute
+    if hasattr(e, "lineno") and e.lineno:
+        template_frames = [{"line": e.lineno, "frame": None, "filename": "<template>"}]
+
+    # Determine if this is an include error (multiple template frames)
+    # When there are multiple frames, it usually means we have an include
+    is_include_error = len(template_frames) > 1
+
+    if template_frames:
+        if is_include_error and len(template_frames) >= 2:
+            error_parts.append(f": {str(e)}")
+
+            # Handle multiple levels of includes
+            if len(template_frames) > 2:
+                # Deep nesting - show the full chain
+                error_parts.append("\n\n  Error occurred through nested includes:")
+
+                # Build the include chain
+                include_chain: list[dict[str, Any]] = []
+                current_content = template_content
+
+                for frame_idx in range(len(template_frames)):
+                    frame_dict = template_frames[frame_idx]
+                    frame_line_no: int = frame_dict["line"]
+                    is_last = frame_idx == len(template_frames) - 1
+
+                    # Get the content to analyze
+                    content_to_analyze = current_content
+
+                    # For intermediate frames, we need the content from the previous snippet
+                    if (
+                        frame_idx > 0
+                        and include_chain
+                        and include_chain[-1].get("next_snippet_name")
+                    ):
+                        prev_snippet_name = include_chain[-1]["next_snippet_name"]
+                        if snippets and prev_snippet_name in snippets:
+                            snippet = snippets[prev_snippet_name]
+                            content_to_analyze = (
+                                snippet.template
+                                if hasattr(snippet, "template")
+                                else str(snippet)
+                            )
+                        else:
+                            # Snippet not found - log this but continue
+                            content_to_analyze = None
+
+                    # Extract context and snippet name
+                    lines = content_to_analyze.split("\n") if content_to_analyze else []
+                    line_idx = frame_line_no - 1
+
+                    snippet_name_for_next = None
+                    if 0 <= line_idx < len(lines) and not is_last:
+                        # Try to extract the snippet name from include statement
+                        snippet_name_for_next = _extract_snippet_name(lines[line_idx])
+
+                    # Store frame info
+                    include_chain.append(
+                        {
+                            "line_no": frame_line_no,
+                            "content": content_to_analyze,
+                            "is_last": is_last,
+                            "next_snippet_name": snippet_name_for_next,
+                            "frame_idx": frame_idx,
+                        }
+                    )
+
+                    # Update current content for next iteration
+                    current_content = content_to_analyze
+
+                # Now display the chain
+                for idx, chain_item in enumerate(include_chain):
+                    if not chain_item["content"]:
+                        # No content available for this frame (e.g., missing snippet)
+                        if idx > 0 and include_chain[idx - 1].get("next_snippet_name"):
+                            snippet_name = include_chain[idx - 1]["next_snippet_name"]
+                            error_parts.append(
+                                f"\n  ↓ Snippet '{snippet_name}' (not found in snippets collection)"
+                            )
+                        continue
+
+                    lines = chain_item["content"].split("\n")
+                    line_idx = chain_item["line_no"] - 1
+
+                    if 0 <= line_idx < len(lines):
+                        # Show context
+                        line_number: int = chain_item["line_no"]
+                        context_lines = _get_context_lines(lines, line_idx, line_number)
+
+                        if context_lines:
+                            if idx == 0:
+                                # Main template
+                                error_parts.append(
+                                    f"\n  Main template (include at line {chain_item['line_no']}):\n"
+                                    + "\n".join(context_lines)
+                                )
+                            elif chain_item["is_last"]:
+                                # Error location - get the snippet name from previous item
+                                snippet_name = None
+                                if idx > 0 and include_chain[idx - 1].get(
+                                    "next_snippet_name"
+                                ):
+                                    snippet_name = include_chain[idx - 1][
+                                        "next_snippet_name"
+                                    ]
+
+                                if snippet_name:
+                                    error_parts.append(
+                                        f"\n  ↓ Snippet '{snippet_name}' (error at line {chain_item['line_no']}):\n"
+                                        + "\n".join(context_lines)
+                                    )
+                                else:
+                                    error_parts.append(
+                                        f"\n  ↓ Error location (line {chain_item['line_no']}):\n"
+                                        + "\n".join(context_lines)
+                                    )
+                            else:
+                                # Intermediate include - get snippet name from previous
+                                snippet_name = None
+                                if idx > 0 and include_chain[idx - 1].get(
+                                    "next_snippet_name"
+                                ):
+                                    snippet_name = include_chain[idx - 1][
+                                        "next_snippet_name"
+                                    ]
+
+                                if snippet_name:
+                                    error_parts.append(
+                                        f"\n  ↓ Snippet '{snippet_name}' (include at line {chain_item['line_no']}):\n"
+                                        + "\n".join(context_lines)
+                                    )
+                                else:
+                                    error_parts.append(
+                                        f"\n  ↓ Include at line {chain_item['line_no']}:\n"
+                                        + "\n".join(context_lines)
+                                    )
+            else:
+                # Simple two-level include (existing logic)
+                include_frame = template_frames[0]
+                error_frame = template_frames[-1]
+                include_line: int = include_frame["line"]
+                error_line: int = error_frame["line"]
+
+                # Show main template context (include statement)
+                snippet_name = None
+                if template_content:
+                    lines = template_content.split("\n")
+                    line_idx = include_line - 1
+
+                    if 0 <= line_idx < len(lines):
+                        # Try to extract snippet name from include statement first
+                        snippet_name = _extract_snippet_name(lines[line_idx])
+
+                        # Show main template context
+                        context_lines = _get_context_lines(
+                            lines, line_idx, include_line
+                        )
+
+                        if context_lines:
+                            error_parts.append(
+                                "\n\n  Error occurred in included snippet"
+                            )
+                            error_parts.append(
+                                "\n  Main template (include at line "
+                                + str(include_line)
+                                + "):\n"
+                                + "\n".join(context_lines)
+                            )
+
+                        # Show snippet context if we have the snippet
+                        if snippet_name and snippets and snippet_name in snippets:
+                            snippet = snippets[snippet_name]
+                            snippet_content = (
+                                snippet.template
+                                if hasattr(snippet, "template")
+                                else str(snippet)
+                            )
+                            snippet_lines = snippet_content.split("\n")
+
+                            # The error_line here is the line number within the snippet
+                            snippet_line_idx = error_line - 1
+
+                            if 0 <= snippet_line_idx < len(snippet_lines):
+                                snippet_context = _get_context_lines(
+                                    snippet_lines, snippet_line_idx, error_line
+                                )
+
+                                if snippet_context:
+                                    error_parts.append(
+                                        f"\n  Snippet '{snippet_name}' (error at line "
+                                        + str(error_line)
+                                        + "):\n"
+                                        + "\n".join(snippet_context)
+                                    )
+        else:
+            # Single frame - regular error
+            line_no: int = template_frames[0]["line"]
+            error_parts.append(f"at line {line_no}")
+            error_parts.append(f": {str(e)}")
+
+            # Show context
+            if template_content and line_no:
+                lines = template_content.split("\n")
+                line_idx = line_no - 1
+
+                context_lines = _get_context_lines(lines, line_idx, line_no)
+                if context_lines:
+                    error_parts.append(
+                        "\n\n  Template context:\n" + "\n".join(context_lines)
+                    )
+    else:
+        # No line number available
+        error_parts.append(f": {str(e)}")
+
+    # Add specific guidance for common errors
+    error_str = str(e).lower()
+    if "nonetype" in error_str and "is not iterable" in error_str:
+        error_parts.append(
+            "\n  💡 Hint: Check if the resource collection exists before iterating. Use: {% for _, item in resources.get('type', {}).items() %}"
+        )
+    elif "undefined" in error_str:
+        error_parts.append(
+            "\n  💡 Hint: A variable is not defined. Check your template variables and resource names."
+        )
+    elif "no filter named" in error_str:
+        error_parts.append(
+            "\n  💡 Hint: Unknown filter. Available filters: b64decode, get_path"
+        )
+    elif "has no attribute" in error_str:
+        error_parts.append(
+            "\n  💡 Hint: Check if the object exists and has the attribute you're trying to access. Consider using default values or conditional checks."
+        )
+
+    return " ".join(error_parts)
 
 
 def get_template_environment(
@@ -289,11 +628,14 @@ class TemplateRenderer:
         """
         return cls(template_snippets=config.template_snippets, config=config)
 
-    def render(self, template_str: str, **context: Any) -> str:
+    def render(
+        self, template_str: str, template_name: Optional[str] = None, **context: Any
+    ) -> str:
         """Compile (with caching) and render a template.
 
         Args:
             template_str: Template string to compile and render
+            template_name: Optional name of the template for error reporting
             **context: Template variables for rendering
 
         Returns:
@@ -302,11 +644,24 @@ class TemplateRenderer:
         Raises:
             ValueError: If template compilation or rendering fails
         """
+        template_name = template_name or "unnamed"
         try:
             template = self.get_compiled(template_str)
             return template.render(**context)
         except Exception as e:
-            raise ValueError(ERROR_TEMPLATE_RENDER.format(error=e)) from e
+            # Format detailed error with context, including snippets
+            snippets_to_use = None
+            if self._compiler.environment.loader and hasattr(
+                self._compiler.environment.loader, "snippets"
+            ):
+                snippets_to_use = self._compiler.environment.loader.snippets  # type: ignore[attr-defined]
+            detailed_error = format_template_error(
+                e,
+                template_name,
+                template_str,
+                snippets_to_use,
+            )
+            raise ValueError(detailed_error) from e
 
     def get_compiled(self, template_str: str) -> Template:
         """Get compiled template (for cases where render is called separately).

--- a/haproxy_template_ic/templating.py
+++ b/haproxy_template_ic/templating.py
@@ -263,8 +263,8 @@ def format_template_error(
                 )
             tb = tb.tb_next
 
-    # For syntax errors, use the lineno attribute
-    if hasattr(e, "lineno") and e.lineno:
+    # For syntax errors, use the lineno attribute only if we don't have frames
+    if not template_frames and hasattr(e, "lineno") and e.lineno:
         template_frames = [{"line": e.lineno, "frame": None, "filename": "<template>"}]
 
     # Determine if this is an include error (multiple template frames)

--- a/haproxy_template_ic/templating.py
+++ b/haproxy_template_ic/templating.py
@@ -10,7 +10,7 @@ import os
 import re
 import sys
 from functools import lru_cache
-from typing import Any, Callable, Dict, Optional, Union, Union
+from typing import Any, Callable, Dict, Optional
 
 from pathvalidate import ValidationError, is_valid_filename, sanitize_filename
 
@@ -273,12 +273,11 @@ def format_template_error(
 
     if template_frames:
         if is_include_error and len(template_frames) >= 2:
-            error_parts.append(f": {str(e)}")
-
             # Handle multiple levels of includes
             if len(template_frames) > 2:
                 # Deep nesting - show the full chain
                 error_parts.append("\n\n  Error occurred through nested includes:")
+                error_parts.append(f"\n  Error: {str(e)}\n")
 
                 # Build the include chain
                 include_chain: list[dict[str, Any]] = []
@@ -423,8 +422,9 @@ def format_template_error(
 
                         if context_lines:
                             error_parts.append(
-                                "\n\n  Error occurred in included snippet"
+                                "\n\n  Error occurred in included snippet:"
                             )
+                            error_parts.append(f"\n  Error: {str(e)}\n")
                             error_parts.append(
                                 "\n  Main template (include at line "
                                 + str(include_line)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "typing-extensions>=4.0.0", # Required by generated client
     "urllib3>=2.0.0", # Required by generated client (with asyncio support)
     "uvloop>=0.21.0",
+    "xxhash>=3.5.0", # Fast non-cryptographic hashing for content change detection
 ]
 
 [dependency-groups]
@@ -44,6 +45,7 @@ dev = [
     "filelock>=3.19.1",
     "lint>=1.2.1",
     "mypy>=1.8.0",
+    "openapi-python-client",
     "oscrypto @ git+https://github.com/wbond/oscrypto.git@d5f3437", # Fix for OpenSSL 3.0.10+ version detection bug
     "prometheus-client>=0.22.1",
     "pytest>=8.4.1",
@@ -71,6 +73,9 @@ package = true
 members = [
     "haproxy-template-ic",
 ]
+
+[tool.uv.sources]
+openapi-python-client = { git = "https://github.com/phihos/openapi-python-client", branch = "enumerate-duplicate-model-names" }
 
 [tool.setuptools.packages.find]
 where = [".", "codegen/haproxy_dataplane_v3"]

--- a/scripts/start-dev-env.sh
+++ b/scripts/start-dev-env.sh
@@ -94,7 +94,7 @@ COMMANDS:
     down        Delete the kind cluster
     logs        Follow controller logs
     exec        Execute shell in controller pod
-    restart     Restart controller deployment
+    restart     Rebuild image and restart controller (use --skip-build to skip)
     status      Show deployment status
     clean       Clean up and reset environment
     test        Test ingress controller functionality
@@ -115,6 +115,8 @@ OPTIONS:
 EXAMPLES:
     $0                      # Start dev environment with defaults
     $0 up --skip-build      # Start without rebuilding image
+    $0 restart              # Rebuild image and restart controller
+    $0 restart --skip-build # Restart controller without rebuilding
     $0 test                 # Test ingress controller functionality
     $0 logs                 # Follow controller logs
     $0 port-forward         # Setup port forwarding for testing
@@ -448,6 +450,19 @@ dev_exec() {
 
 dev_restart() {
     print_section "🔄 Restarting Controller"
+    
+    # Build and load new image unless skipped
+    if [[ "$SKIP_BUILD" != "true" ]]; then
+        log INFO "Rebuilding and loading controller image..."
+        build_and_load_local_image || {
+            err "Failed to rebuild image"
+            return 1
+        }
+    else
+        log INFO "Skipping image rebuild (--skip-build flag set)"
+    fi
+    
+    # Restart the deployment with the new image
     kubectl -n "$CTRL_NAMESPACE" rollout restart deploy/haproxy-template-ic
     kubectl -n "$CTRL_NAMESPACE" rollout status deploy/haproxy-template-ic --timeout="${TIMEOUT}s"
     ok "Controller restarted successfully"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,36 +340,41 @@ def kind_cluster(request):
             cluster_exists = name in out.splitlines()
 
             if cluster_exists:
-                # Check if kubeconfig exists but is empty or missing clusters
-                if cluster.kubeconfig_path.exists():
+                # Check if kubeconfig needs to be exported from existing cluster
+                need_export = False
+
+                if not cluster.kubeconfig_path.exists():
+                    # Kubeconfig doesn't exist at all
+                    need_export = True
+                else:
+                    # Check if kubeconfig exists but is empty or missing required fields
                     try:
                         with open(cluster.kubeconfig_path, "r") as f:
                             config_content = yaml.safe_load(f)
 
-                        # If kubeconfig is empty or missing clusters, export from kind
+                        # If kubeconfig is empty, missing clusters, or missing current-context, export from kind
                         if (
                             not config_content
                             or "clusters" not in config_content
                             or not config_content["clusters"]
+                            or "current-context" not in config_content
+                            or not config_content.get("current-context")
                         ):
-                            # Export kubeconfig from the existing cluster
-                            kubeconfig_output = subprocess.check_output(
-                                ["kind", "get", "kubeconfig", "--name", name],
-                                encoding="utf-8",
-                            )
-
-                            with open(cluster.kubeconfig_path, "w") as f:
-                                f.write(kubeconfig_output)
+                            need_export = True
 
                     except (yaml.YAMLError, FileNotFoundError):
                         # If kubeconfig is malformed, regenerate it
-                        kubeconfig_output = subprocess.check_output(
-                            ["kind", "get", "kubeconfig", "--name", name],
-                            encoding="utf-8",
-                        )
+                        need_export = True
 
-                        with open(cluster.kubeconfig_path, "w") as f:
-                            f.write(kubeconfig_output)
+                if need_export:
+                    # Export kubeconfig from the existing cluster
+                    kubeconfig_output = subprocess.check_output(
+                        ["kind", "get", "kubeconfig", "--name", name],
+                        encoding="utf-8",
+                    )
+
+                    with open(cluster.kubeconfig_path, "w") as f:
+                        f.write(kubeconfig_output)
 
         except subprocess.CalledProcessError:
             # kind command failed, let create() handle cluster creation

--- a/tests/e2e/test_pod_discovery.py
+++ b/tests/e2e/test_pod_discovery.py
@@ -57,6 +57,7 @@ def get_pod_ips_from_socket_response(response):
         if "indices" in response and "haproxy_pods" in response["indices"]:
             ips = []
             haproxy_pods_index = response["indices"]["haproxy_pods"]
+
             for key, resources in haproxy_pods_index.items():
                 # Resources might be a list or a single resource
                 if isinstance(resources, list):
@@ -65,31 +66,74 @@ def get_pod_ips_from_socket_response(response):
                     resource_list = [resources]
 
                 for resource in resource_list:
+                    pod_ip = None
+
                     # Handle string representation of dictionaries
                     if isinstance(resource, str):
                         try:
                             resource = ast.literal_eval(resource)
                         except (ValueError, SyntaxError):
+                            # Try extracting IP from string directly
+                            ip_matches = re.findall(
+                                r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b", str(resource)
+                            )
+                            if ip_matches:
+                                ips.extend(ip_matches)
                             continue
 
                     if isinstance(resource, dict):
-                        # Extract pod IP from resource status
+                        # Try multiple ways to extract IP
+                        # 1. Try status.podIP (standard k8s pod structure)
                         if "status" in resource and isinstance(
                             resource["status"], dict
                         ):
                             pod_ip = resource["status"].get("podIP")
-                            if pod_ip:
-                                ips.append(pod_ip)
-            return ips
+                        # 2. Try spec.podIP
+                        elif "spec" in resource and isinstance(resource["spec"], dict):
+                            pod_ip = resource["spec"].get("podIP")
+                        # 3. Try direct podIP field
+                        elif "podIP" in resource:
+                            pod_ip = resource["podIP"]
+                        # 4. Look for nested pod object
+                        elif "pod" in resource and isinstance(resource["pod"], dict):
+                            if "status" in resource["pod"] and isinstance(
+                                resource["pod"]["status"], dict
+                            ):
+                                pod_ip = resource["pod"]["status"].get("podIP")
+
+                        # 5. If still no IP, extract from string representation
+                        if not pod_ip:
+                            resource_str = str(resource)
+                            ip_matches = re.findall(
+                                r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b", resource_str
+                            )
+                            if ip_matches:
+                                ips.extend(ip_matches)
+                                continue
+
+                    if pod_ip:
+                        ips.append(pod_ip)
+
+            # Remove duplicates while preserving order
+            seen = set()
+            unique_ips = []
+            for ip in ips:
+                if ip not in seen:
+                    seen.add(ip)
+                    unique_ips.append(ip)
+            return unique_ips
 
         # Fall back to string representation
         response_str = str(response)
     else:
         response_str = str(response)
 
-    # Fall back to regex extraction of IP addresses
+    # Fall back to regex extraction of IP addresses from entire response
     ip_pattern = r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
-    return re.findall(ip_pattern, response_str)
+    all_ips = re.findall(ip_pattern, response_str)
+    # Filter out common non-pod IPs (localhost, DNS, etc)
+    filtered_ips = [ip for ip in all_ips if not ip.startswith(("127.", "0.0.0.0"))]
+    return filtered_ips
 
 
 def wait_for_deployment_replicas(deployment, expected_replicas, timeout=60):
@@ -127,7 +171,26 @@ async def test_pod_discovery_with_scaling(
     # Step 1: Wait for controller to discover initial HAProxy pods (2 instances)
     async def check_initial_discovery():
         response = send_socket_command(ingress_controller, "dump all")
+        # Debug logging to understand response structure
+        print(f"DEBUG: Response type: {type(response)}")
+        if isinstance(response, dict):
+            print(f"DEBUG: Response keys: {response.keys()}")
+            if "indices" in response:
+                print(f"DEBUG: Indices keys: {response.get('indices', {}).keys()}")
+                if "haproxy_pods" in response.get("indices", {}):
+                    haproxy_pods = response["indices"]["haproxy_pods"]
+                    print(f"DEBUG: haproxy_pods type: {type(haproxy_pods)}")
+                    if isinstance(haproxy_pods, dict) and haproxy_pods:
+                        first_key = list(haproxy_pods.keys())[0]
+                        print(f"DEBUG: First key in haproxy_pods: {first_key}")
+                        print(
+                            f"DEBUG: First value type: {type(haproxy_pods[first_key])}"
+                        )
+                        print(
+                            f"DEBUG: First value sample: {str(haproxy_pods[first_key])[:500]}"
+                        )
         discovered_ips = get_pod_ips_from_socket_response(response)
+        print(f"DEBUG: Discovered IPs: {discovered_ips}")
 
         # Get actual HAProxy pod IPs for validation
         haproxy_pods = k8s_client.get(
@@ -136,6 +199,7 @@ async def test_pod_discovery_with_scaling(
             namespace=k8s_namespace,
         )
         actual_ips = [pod.status.podIP for pod in haproxy_pods if pod.status.podIP]
+        print(f"DEBUG: Actual pod IPs: {actual_ips}")
 
         # Check if we have at least 2 discovered instances and they match actual IPs
         if len(discovered_ips) >= 2:

--- a/tests/unit/test_dataplane.py
+++ b/tests/unit/test_dataplane.py
@@ -6,6 +6,7 @@ client operations, and configuration synchronization.
 """
 
 import asyncio
+import io
 import pytest
 from unittest.mock import Mock, AsyncMock, MagicMock, patch
 from unittest import mock
@@ -82,6 +83,13 @@ class MockAttemptManager:
             # Don't suppress the exception - let it propagate for retry logic
             return False
         return True
+
+
+@pytest.fixture(autouse=True, scope="module")
+def mock_async_retrying():
+    """Apply MockAsyncRetrying to all tests in this module to eliminate retry delays."""
+    with patch("haproxy_template_ic.dataplane.AsyncRetrying", MockAsyncRetrying):
+        yield
 
 
 class TestDeploymentHistory:
@@ -891,31 +899,45 @@ class TestDataplaneClientSyncMethods:
                 "haproxy_template_ic.dataplane.get_all_storage_map_files"
             ) as mock_get_maps:
                 with patch(
-                    "haproxy_template_ic.dataplane.create_storage_map_file"
-                ) as mock_create:
+                    "haproxy_template_ic.dataplane.get_one_storage_map"
+                ) as mock_get_one:
                     with patch(
-                        "haproxy_template_ic.dataplane.delete_storage_map"
-                    ) as mock_delete:
-                        # Set up existing maps
-                        mock_get_maps.asyncio = AsyncMock(
-                            return_value=[mock_existing_map]
-                        )
-                        mock_create.asyncio = AsyncMock(return_value=None)
-                        mock_delete.asyncio = AsyncMock(return_value=None)
+                        "haproxy_template_ic.dataplane.create_storage_map_file"
+                    ) as mock_create:
+                        with patch(
+                            "haproxy_template_ic.dataplane.replace_storage_map_file"
+                        ) as mock_replace:
+                            # Set up existing maps
+                            mock_get_maps.asyncio = AsyncMock(
+                                return_value=[mock_existing_map]
+                            )
 
-                        maps_to_sync = {
-                            "new.map": "new map content",
-                            "existing.map": "updated content",
-                        }
+                            # Mock get_one to return different content (triggering update)
+                            mock_existing_content = Mock()
+                            mock_existing_content.payload = io.BytesIO(b"old content")
+                            mock_get_one.asyncio = AsyncMock(
+                                return_value=mock_existing_content
+                            )
 
-                        await client.sync_maps(maps_to_sync)
+                            mock_create.asyncio = AsyncMock(return_value=None)
+                            mock_replace.asyncio = AsyncMock(return_value=None)
 
-                        # Verify create was called for new map
-                        mock_create.asyncio.assert_called()
-                        # Verify delete+create was called for existing map update
-                        mock_delete.asyncio.assert_called_with(
-                            client=mock_api_client, name="existing.map"
-                        )
+                            maps_to_sync = {
+                                "new.map": "new map content",
+                                "existing.map": "updated content",
+                            }
+
+                            await client.sync_maps(maps_to_sync)
+
+                            # Verify create was called for new map
+                            mock_create.asyncio.assert_called()
+
+                            # Verify replace was called for existing map update
+                            mock_replace.asyncio.assert_called_with(
+                                client=mock_api_client,
+                                name="existing.map",
+                                body="updated content",
+                            )
 
     @pytest.mark.asyncio
     async def test_sync_maps_with_obsolete_maps(self):
@@ -935,27 +957,38 @@ class TestDataplaneClientSyncMethods:
                 "haproxy_template_ic.dataplane.get_all_storage_map_files"
             ) as mock_get_maps:
                 with patch(
-                    "haproxy_template_ic.dataplane.create_storage_map_file"
-                ) as mock_create:
+                    "haproxy_template_ic.dataplane.get_one_storage_map"
+                ) as mock_get_one:
                     with patch(
-                        "haproxy_template_ic.dataplane.delete_storage_map"
-                    ) as mock_delete:
-                        mock_get_maps.asyncio = AsyncMock(
-                            return_value=[mock_existing_map, mock_keep_map]
-                        )
-                        mock_create.asyncio = AsyncMock(return_value=None)
-                        mock_delete.asyncio = AsyncMock(return_value=None)
+                        "haproxy_template_ic.dataplane.replace_storage_map_file"
+                    ) as mock_replace:
+                        with patch(
+                            "haproxy_template_ic.dataplane.delete_storage_map"
+                        ) as mock_delete:
+                            mock_get_maps.asyncio = AsyncMock(
+                                return_value=[mock_existing_map, mock_keep_map]
+                            )
 
-                        maps_to_sync = {
-                            "keep.map": "updated content",
-                        }
+                            # Mock get_one to return different content for keep.map
+                            mock_existing_content = Mock()
+                            mock_existing_content.payload = io.BytesIO(b"old content")
+                            mock_get_one.asyncio = AsyncMock(
+                                return_value=mock_existing_content
+                            )
 
-                        await client.sync_maps(maps_to_sync)
+                            mock_replace.asyncio = AsyncMock(return_value=None)
+                            mock_delete.asyncio = AsyncMock(return_value=None)
 
-                        # Verify obsolete map was deleted
-                        mock_delete.asyncio.assert_any_call(
-                            client=mock_api_client, name="obsolete.map"
-                        )
+                            maps_to_sync = {
+                                "keep.map": "updated content",
+                            }
+
+                            await client.sync_maps(maps_to_sync)
+
+                            # Verify obsolete map was deleted
+                            mock_delete.asyncio.assert_any_call(
+                                client=mock_api_client, name="obsolete.map"
+                            )
 
     @pytest.mark.asyncio
     async def test_sync_maps_error_handling(self):
@@ -994,30 +1027,46 @@ class TestDataplaneClientSyncMethods:
                 "haproxy_template_ic.dataplane.get_all_storage_ssl_certificates"
             ) as mock_get_certs:
                 with patch(
-                    "haproxy_template_ic.dataplane.create_storage_ssl_certificate"
-                ) as mock_create:
+                    "haproxy_template_ic.dataplane.get_one_storage_ssl_certificate"
+                ) as mock_get_one:
                     with patch(
-                        "haproxy_template_ic.dataplane.delete_storage_ssl_certificate"
-                    ) as mock_delete:
-                        mock_get_certs.asyncio = AsyncMock(
-                            return_value=[mock_existing_cert]
-                        )
-                        mock_create.asyncio = AsyncMock(return_value=None)
-                        mock_delete.asyncio = AsyncMock(return_value=None)
+                        "haproxy_template_ic.dataplane.create_storage_ssl_certificate"
+                    ) as mock_create:
+                        with patch(
+                            "haproxy_template_ic.dataplane.replace_storage_ssl_certificate"
+                        ) as mock_replace:
+                            mock_get_certs.asyncio = AsyncMock(
+                                return_value=[mock_existing_cert]
+                            )
 
-                        certs_to_sync = {
-                            "new.pem": "-----BEGIN CERTIFICATE-----\nnew cert\n-----END CERTIFICATE-----",
-                            "existing.pem": "-----BEGIN CERTIFICATE-----\nupdated cert\n-----END CERTIFICATE-----",
-                        }
+                            # Mock get_one to return different content (triggering update)
+                            mock_existing_content = Mock()
+                            mock_existing_content.payload = io.BytesIO(
+                                b"-----BEGIN CERTIFICATE-----\nold cert\n-----END CERTIFICATE-----"
+                            )
+                            mock_get_one.asyncio = AsyncMock(
+                                return_value=mock_existing_content
+                            )
 
-                        await client.sync_certificates(certs_to_sync)
+                            mock_create.asyncio = AsyncMock(return_value=None)
+                            mock_replace.asyncio = AsyncMock(return_value=None)
 
-                        # Verify create was called for new cert
-                        mock_create.asyncio.assert_called()
-                        # Verify delete+create was called for existing cert update
-                        mock_delete.asyncio.assert_called_with(
-                            client=mock_api_client, name="existing.pem"
-                        )
+                            certs_to_sync = {
+                                "new.pem": "-----BEGIN CERTIFICATE-----\nnew cert\n-----END CERTIFICATE-----",
+                                "existing.pem": "-----BEGIN CERTIFICATE-----\nupdated cert\n-----END CERTIFICATE-----",
+                            }
+
+                            await client.sync_certificates(certs_to_sync)
+
+                            # Verify create was called for new cert
+                            mock_create.asyncio.assert_called()
+
+                            # Verify replace was called for existing cert update
+                            mock_replace.asyncio.assert_called_with(
+                                client=mock_api_client,
+                                name="existing.pem",
+                                body="-----BEGIN CERTIFICATE-----\nupdated cert\n-----END CERTIFICATE-----",
+                            )
 
     @pytest.mark.asyncio
     async def test_sync_certificates_error_handling(self):
@@ -1962,15 +2011,12 @@ class TestDataplaneClientDeploymentRetryLogic:
                 "Network always fails"
             )
 
-            # Mock the retry mechanism to avoid actual waits
-            with patch(
-                "haproxy_template_ic.dataplane.AsyncRetrying", MockAsyncRetrying
-            ):
-                with pytest.raises(DataplaneAPIError) as exc_info:
-                    await client.deploy_configuration("global\n    daemon\n")
+            # Retry mechanism is already mocked globally by the fixture
+            with pytest.raises(DataplaneAPIError) as exc_info:
+                await client.deploy_configuration("global\n    daemon\n")
 
-                assert "Configuration deployment failed" in str(exc_info.value)
-                assert exc_info.value.operation == "deploy"
+            assert "Configuration deployment failed" in str(exc_info.value)
+            assert exc_info.value.operation == "deploy"
 
 
 class TestConditionalDeployment:

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -531,7 +531,10 @@ async def test_render_haproxy_templates_jinja_error(
 
     # Should log error but not crash
     mock_logger.error.assert_called()
-    assert "Failed to render" in mock_logger.error.call_args_list[0][0][0]
+    # Check for the new detailed error format
+    error_msg = mock_logger.error.call_args_list[0][0][0]
+    assert "Template 'map/backend.map' rendering failed" in error_msg
+    assert "'undefined_variable' is undefined" in error_msg
     # Sync should be called but will handle the error gracefully
     mock_sync.assert_called_once()
 
@@ -624,7 +627,8 @@ async def test_render_haproxy_config_jinja_error(
 
     # Should log error but not crash, and rendered_config should be None
     mock_logger.error.assert_called()
-    assert "Failed to render HAProxy configuration template" in str(
+    # Check for the new detailed error format
+    assert "Template 'haproxy_config' rendering failed" in str(
         mock_logger.error.call_args
     )
     assert memo.haproxy_config_context.rendered_config is None
@@ -738,7 +742,7 @@ async def test_render_certificates_jinja_error(
     # Check for certificate error in any of the error calls
     error_messages = [str(call) for call in mock_logger.error.call_args_list]
     assert any(
-        "Failed to render certificate template for bad-cert.pem" in msg
+        "Template 'certificate/bad-cert.pem' rendering failed" in msg
         for msg in error_messages
     )
 

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -21,6 +21,9 @@ from haproxy_template_ic.templating import (
     render_template,
     TemplateRenderer,
     validate_config_templates,
+    format_template_error,
+    _extract_snippet_name,
+    _get_context_lines,
 )
 from haproxy_template_ic.config_models import TemplateSnippet
 
@@ -1053,3 +1056,292 @@ class TestGetPathFilterSecurity:
                 ValueError, match="(unsafe characters|prohibited characters)"
             ):
                 get_path_filter(invalid_filename, "map")
+
+
+class TestFormatTemplateError:
+    """Test the format_template_error function for comprehensive error formatting."""
+
+    def test_format_template_error_simple(self):
+        """Test formatting a simple template error without line numbers."""
+        error = ValueError("Simple error message")
+        result = format_template_error(error, "test_template")
+
+        assert "Template 'test_template' rendering failed" in result
+        assert "Simple error message" in result
+
+    def test_format_template_error_with_line_number(self):
+        """Test formatting an error with line number information."""
+        error = TemplateSyntaxError("Syntax error", lineno=5)
+        template_content = "\n".join(
+            [
+                "line 1",
+                "line 2",
+                "line 3",
+                "line 4",
+                "line 5 with error",
+                "line 6",
+                "line 7",
+            ]
+        )
+
+        result = format_template_error(error, "test_template", template_content)
+
+        assert "Template 'test_template' rendering failed" in result
+        assert "at line 5" in result
+        assert ">>> line 5 with error" in result
+        assert "Template context:" in result
+
+    def test_format_template_error_deeply_nested_includes(self):
+        """Test error formatting for 3+ level nested includes."""
+        # Create mock exception with deep traceback
+        error = ValueError("Error in deeply nested snippet")
+
+        # Create snippets for testing
+        snippets = {
+            "level1": TemplateSnippet(
+                name="level1", template='First level\n{% include "level2" %}\nEnd first'
+            ),
+            "level2": TemplateSnippet(
+                name="level2",
+                template='Second level\n{% include "level3" %}\nEnd second',
+            ),
+            "level3": TemplateSnippet(
+                name="level3", template="Third level\n{{ undefined_var }}\nEnd third"
+            ),
+        }
+
+        template_content = 'Main template\n{% include "level1" %}\nEnd main'
+
+        # We can't easily mock sys.exc_info, so test the formatting logic directly
+        # by testing the helper functions instead
+        result = format_template_error(
+            error, "main_template", template_content, snippets
+        )
+
+        assert "Template 'main_template' rendering failed" in result
+        assert "Error in deeply nested snippet" in result
+
+    def test_format_template_error_missing_snippet(self):
+        """Test handling of missing snippets in include chain."""
+        error = TemplateNotFound("missing_snippet")
+        template_content = 'Main template\n{% include "missing_snippet" %}\nEnd main'
+
+        result = format_template_error(error, "test_template", template_content)
+
+        assert "Template 'test_template' rendering failed" in result
+        assert "missing_snippet" in result
+
+    def test_format_template_error_syntax_errors(self):
+        """Test syntax error formatting with line context."""
+        error = TemplateSyntaxError("Encountered unknown tag 'endpoint'", lineno=4)
+        template_content = """global
+    daemon
+frontend main
+    {% endpoint in some_list %}
+    bind *:80
+backend servers
+    server web1 10.0.0.1:80"""
+
+        result = format_template_error(error, "haproxy_config", template_content)
+
+        assert "Template 'haproxy_config' rendering failed" in result
+        assert "at line 4" in result
+        assert "Encountered unknown tag 'endpoint'" in result
+        assert ">>> " in result  # Context line marker
+        assert "endpoint in some_list" in result
+
+    def test_format_template_error_nonetype_hint(self):
+        """Test that NoneType errors get helpful hints."""
+        error = TypeError("'NoneType' object is not iterable")
+        result = format_template_error(error, "test_template")
+
+        assert "Template 'test_template' rendering failed" in result
+        assert "'NoneType' object is not iterable" in result
+        assert "💡 Hint:" in result
+        assert "resources.get('type', {}).items()" in result
+
+    def test_format_template_error_undefined_hint(self):
+        """Test that undefined variable errors get helpful hints."""
+        error = NameError("undefined variable 'foo'")
+        result = format_template_error(error, "test_template")
+
+        assert "Template 'test_template' rendering failed" in result
+        assert "undefined variable" in result
+        assert "💡 Hint:" in result
+        assert "variable is not defined" in result
+
+    def test_format_template_error_filter_hint(self):
+        """Test that filter errors get helpful hints."""
+        error = ValueError("no filter named 'unknown_filter'")
+        result = format_template_error(error, "test_template")
+
+        assert "Template 'test_template' rendering failed" in result
+        assert "no filter named" in result
+        assert "💡 Hint:" in result
+        assert "Available filters: b64decode, get_path" in result
+
+    def test_format_template_error_attribute_hint(self):
+        """Test that attribute errors get helpful hints."""
+        error = AttributeError("'dict' object has no attribute 'missing'")
+        result = format_template_error(error, "test_template")
+
+        assert "Template 'test_template' rendering failed" in result
+        assert "has no attribute" in result
+        assert "💡 Hint:" in result
+        assert "Check if the object exists" in result
+
+    def test_format_template_error_two_level_include(self):
+        """Test formatting for simple two-level includes."""
+        error = ValueError("Error in snippet")
+
+        snippets = {
+            "backend-servers": TemplateSnippet(
+                name="backend-servers",
+                template="{% for server in servers %}\n  server {{ server }}\n{% endfor %}",
+            ),
+        }
+
+        template_content = (
+            'frontend main\n    {% include "backend-servers" %}\nbackend fallback'
+        )
+
+        # Since we can't easily mock the traceback, test the basic formatting
+        result = format_template_error(error, "main_config", template_content, snippets)
+
+        assert "Template 'main_config' rendering failed" in result
+        assert "Error in snippet" in result
+
+    def test_format_template_error_empty_template(self):
+        """Test formatting with empty or None template content."""
+        error = ValueError("Some error")
+
+        # Test with None template
+        result1 = format_template_error(error, "test", None)
+        assert "Template 'test' rendering failed" in result1
+        assert "Some error" in result1
+
+        # Test with empty template
+        result2 = format_template_error(error, "test", "")
+        assert "Template 'test' rendering failed" in result2
+        assert "Some error" in result2
+
+    def test_format_template_error_invalid_line_numbers(self):
+        """Test handling of invalid line numbers."""
+        error = TemplateSyntaxError("Error", lineno=-1)
+        template_content = "line 1\nline 2"
+
+        result = format_template_error(error, "test", template_content)
+        assert "Template 'test' rendering failed" in result
+        assert "Error" in result
+        # Should handle gracefully without crashing
+
+    def test_format_template_error_long_error_messages(self):
+        """Test formatting with very long error messages."""
+        long_message = "Error: " + "x" * 1000
+        error = ValueError(long_message)
+
+        result = format_template_error(error, "test")
+        assert "Template 'test' rendering failed" in result
+        assert "Error:" in result
+        assert "x" * 100 in result  # Should contain at least part of the message
+
+
+class TestExtractSnippetName:
+    """Test the _extract_snippet_name helper function."""
+
+    def test_extract_snippet_name_single_quotes(self):
+        """Test extracting snippet name with single quotes."""
+        line = "    {% include 'backend-servers' %}"
+        result = _extract_snippet_name(line)
+        assert result == "backend-servers"
+
+    def test_extract_snippet_name_double_quotes(self):
+        """Test extracting snippet name with double quotes."""
+        line = '    {% include "frontend-config" %}'
+        result = _extract_snippet_name(line)
+        assert result == "frontend-config"
+
+    def test_extract_snippet_name_with_spaces(self):
+        """Test extracting snippet name with varying spaces."""
+        line = "{%   include   'test-snippet'   %}"
+        result = _extract_snippet_name(line)
+        assert result == "test-snippet"
+
+    def test_extract_snippet_name_no_include(self):
+        """Test when line doesn't contain include statement."""
+        line = "    server web1 10.0.0.1:80"
+        result = _extract_snippet_name(line)
+        assert result is None
+
+    def test_extract_snippet_name_malformed(self):
+        """Test with malformed include statement."""
+        line = "{% include without quotes %}"
+        result = _extract_snippet_name(line)
+        assert result is None
+
+    def test_extract_snippet_name_partial(self):
+        """Test with partial include keyword."""
+        line = "# This line includes something"
+        result = _extract_snippet_name(line)
+        assert result is None
+
+
+class TestGetContextLines:
+    """Test the _get_context_lines helper function."""
+
+    def test_get_context_lines_basic(self):
+        """Test getting context lines around a target line."""
+        lines = ["line 1", "line 2", "line 3", "line 4", "line 5"]
+        result = _get_context_lines(lines, 2, 3, context_before=1, context_after=1)
+
+        assert len(result) == 3
+        assert "2:" in result[0]
+        assert ">>> line 3" in result[1]
+        assert "4:" in result[2]
+
+    def test_get_context_lines_at_start(self):
+        """Test getting context lines at the start of file."""
+        lines = ["line 1", "line 2", "line 3", "line 4", "line 5"]
+        result = _get_context_lines(lines, 0, 1, context_before=2, context_after=2)
+
+        assert ">>> line 1" in result[0]
+        assert "line 2" in result[1]
+        assert "line 3" in result[2]
+
+    def test_get_context_lines_at_end(self):
+        """Test getting context lines at the end of file."""
+        lines = ["line 1", "line 2", "line 3", "line 4", "line 5"]
+        result = _get_context_lines(lines, 4, 5, context_before=2, context_after=2)
+
+        assert "line 3" in result[0]
+        assert "line 4" in result[1]
+        assert ">>> line 5" in result[2]
+
+    def test_get_context_lines_empty_list(self):
+        """Test with empty lines list."""
+        result = _get_context_lines([], 0, 1)
+        assert result == []
+
+    def test_get_context_lines_invalid_index(self):
+        """Test with invalid line index."""
+        lines = ["line 1", "line 2"]
+        result = _get_context_lines(lines, -1, 0)
+        assert result == []
+
+        result = _get_context_lines(lines, 5, 6)
+        assert result == []
+
+    def test_get_context_lines_formatting(self):
+        """Test that context lines are properly formatted."""
+        lines = ["first", "second", "third"]
+        result = _get_context_lines(lines, 1, 2, context_before=1, context_after=1)
+
+        # Check line number formatting
+        assert "1:" in result[0]
+        assert "2:" in result[1]
+        assert "3:" in result[2]
+
+        # Check marker for target line
+        assert ">>> " in result[1]
+        assert ">>> " not in result[0]
+        assert ">>> " not in result[2]

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -411,7 +411,7 @@ class TestTemplateRenderer:
         renderer = TemplateRenderer()
         template_str = "{{ undefined_var.missing_attr }}"
 
-        with pytest.raises(ValueError, match="Template rendering failed"):
+        with pytest.raises(ValueError, match="Template 'unnamed' rendering failed"):
             renderer.render(template_str)
 
     def test_get_compiled_success(self):

--- a/uv.lock
+++ b/uv.lock
@@ -242,24 +242,33 @@ wheels = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.2"
+version = "3.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63", size = 126367, upload-time = "2025-05-02T08:34:42.01Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz", hash = "sha256:6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14", size = 122371, upload-time = "2025-08-09T07:57:28.46Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/12/a93df3366ed32db1d907d7593a94f1fe6293903e3e92967bebd6950ed12c/charset_normalizer-3.4.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0", size = 199622, upload-time = "2025-05-02T08:32:56.363Z" },
-    { url = "https://files.pythonhosted.org/packages/04/93/bf204e6f344c39d9937d3c13c8cd5bbfc266472e51fc8c07cb7f64fcd2de/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf", size = 143435, upload-time = "2025-05-02T08:32:58.551Z" },
-    { url = "https://files.pythonhosted.org/packages/22/2a/ea8a2095b0bafa6c5b5a55ffdc2f924455233ee7b91c69b7edfcc9e02284/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e", size = 153653, upload-time = "2025-05-02T08:33:00.342Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/57/1b090ff183d13cef485dfbe272e2fe57622a76694061353c59da52c9a659/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1", size = 146231, upload-time = "2025-05-02T08:33:02.081Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c", size = 148243, upload-time = "2025-05-02T08:33:04.063Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/0f/9abe9bd191629c33e69e47c6ef45ef99773320e9ad8e9cb08b8ab4a8d4cb/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691", size = 150442, upload-time = "2025-05-02T08:33:06.418Z" },
-    { url = "https://files.pythonhosted.org/packages/67/7c/a123bbcedca91d5916c056407f89a7f5e8fdfce12ba825d7d6b9954a1a3c/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0", size = 145147, upload-time = "2025-05-02T08:33:08.183Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/fe/1ac556fa4899d967b83e9893788e86b6af4d83e4726511eaaad035e36595/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b", size = 153057, upload-time = "2025-05-02T08:33:09.986Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/ff/acfc0b0a70b19e3e54febdd5301a98b72fa07635e56f24f60502e954c461/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff", size = 156454, upload-time = "2025-05-02T08:33:11.814Z" },
-    { url = "https://files.pythonhosted.org/packages/92/08/95b458ce9c740d0645feb0e96cea1f5ec946ea9c580a94adfe0b617f3573/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b", size = 154174, upload-time = "2025-05-02T08:33:13.707Z" },
-    { url = "https://files.pythonhosted.org/packages/78/be/8392efc43487ac051eee6c36d5fbd63032d78f7728cb37aebcc98191f1ff/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148", size = 149166, upload-time = "2025-05-02T08:33:15.458Z" },
-    { url = "https://files.pythonhosted.org/packages/44/96/392abd49b094d30b91d9fbda6a69519e95802250b777841cf3bda8fe136c/charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7", size = 98064, upload-time = "2025-05-02T08:33:17.06Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/b0/0200da600134e001d91851ddc797809e2fe0ea72de90e09bec5a2fbdaccb/charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980", size = 105641, upload-time = "2025-05-02T08:33:18.753Z" },
-    { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626, upload-time = "2025-05-02T08:34:40.053Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ca/2135ac97709b400c7654b4b764daf5c5567c2da45a30cdd20f9eefe2d658/charset_normalizer-3.4.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:14c2a87c65b351109f6abfc424cab3927b3bdece6f706e4d12faaf3d52ee5efe", size = 205326, upload-time = "2025-08-09T07:56:24.721Z" },
+    { url = "https://files.pythonhosted.org/packages/71/11/98a04c3c97dd34e49c7d247083af03645ca3730809a5509443f3c37f7c99/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41d1fc408ff5fdfb910200ec0e74abc40387bccb3252f3f27c0676731df2b2c8", size = 146008, upload-time = "2025-08-09T07:56:26.004Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/4659a4cb3c4ec146bec80c32d8bb16033752574c20b1252ee842a95d1a1e/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1bb60174149316da1c35fa5233681f7c0f9f514509b8e399ab70fea5f17e45c9", size = 159196, upload-time = "2025-08-09T07:56:27.25Z" },
+    { url = "https://files.pythonhosted.org/packages/86/9e/f552f7a00611f168b9a5865a1414179b2c6de8235a4fa40189f6f79a1753/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30d006f98569de3459c2fc1f2acde170b7b2bd265dc1943e87e1a4efe1b67c31", size = 156819, upload-time = "2025-08-09T07:56:28.515Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/95/42aa2156235cbc8fa61208aded06ef46111c4d3f0de233107b3f38631803/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:416175faf02e4b0810f1f38bcb54682878a4af94059a1cd63b8747244420801f", size = 151350, upload-time = "2025-08-09T07:56:29.716Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a9/3865b02c56f300a6f94fc631ef54f0a8a29da74fb45a773dfd3dcd380af7/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6aab0f181c486f973bc7262a97f5aca3ee7e1437011ef0c2ec04b5a11d16c927", size = 148644, upload-time = "2025-08-09T07:56:30.984Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d9/cbcf1a2a5c7d7856f11e7ac2d782aec12bdfea60d104e60e0aa1c97849dc/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:fdabf8315679312cfa71302f9bd509ded4f2f263fb5b765cf1433b39106c3cc9", size = 160468, upload-time = "2025-08-09T07:56:32.252Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/42/6f45efee8697b89fda4d50580f292b8f7f9306cb2971d4b53f8914e4d890/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:bd28b817ea8c70215401f657edef3a8aa83c29d447fb0b622c35403780ba11d5", size = 158187, upload-time = "2025-08-09T07:56:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/70/99/f1c3bdcfaa9c45b3ce96f70b14f070411366fa19549c1d4832c935d8e2c3/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:18343b2d246dc6761a249ba1fb13f9ee9a2bcd95decc767319506056ea4ad4dc", size = 152699, upload-time = "2025-08-09T07:56:34.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ad/b0081f2f99a4b194bcbb1934ef3b12aa4d9702ced80a37026b7607c72e58/charset_normalizer-3.4.3-cp313-cp313-win32.whl", hash = "sha256:6fb70de56f1859a3f71261cbe41005f56a7842cc348d3aeb26237560bfa5e0ce", size = 99580, upload-time = "2025-08-09T07:56:35.981Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/8f/ae790790c7b64f925e5c953b924aaa42a243fb778fed9e41f147b2a5715a/charset_normalizer-3.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:cf1ebb7d78e1ad8ec2a8c4732c7be2e736f6e5123a4146c5b89c9d1f585f8cef", size = 107366, upload-time = "2025-08-09T07:56:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/91/b5a06ad970ddc7a0e513112d40113e834638f4ca1120eb727a249fb2715e/charset_normalizer-3.4.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3cd35b7e8aedeb9e34c41385fda4f73ba609e561faedfae0a9e75e44ac558a15", size = 204342, upload-time = "2025-08-09T07:56:38.687Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ec/1edc30a377f0a02689342f214455c3f6c2fbedd896a1d2f856c002fc3062/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b89bc04de1d83006373429975f8ef9e7932534b8cc9ca582e4db7d20d91816db", size = 145995, upload-time = "2025-08-09T07:56:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e5/5e67ab85e6d22b04641acb5399c8684f4d37caf7558a53859f0283a650e9/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2001a39612b241dae17b4687898843f254f8748b796a2e16f1051a17078d991d", size = 158640, upload-time = "2025-08-09T07:56:41.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e5/38421987f6c697ee3722981289d554957c4be652f963d71c5e46a262e135/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8dcfc373f888e4fb39a7bc57e93e3b845e7f462dacc008d9749568b1c4ece096", size = 156636, upload-time = "2025-08-09T07:56:43.195Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e4/5a075de8daa3ec0745a9a3b54467e0c2967daaaf2cec04c845f73493e9a1/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b97b8404387b96cdbd30ad660f6407799126d26a39ca65729162fd810a99aa", size = 150939, upload-time = "2025-08-09T07:56:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f7/3611b32318b30974131db62b4043f335861d4d9b49adc6d57c1149cc49d4/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ccf600859c183d70eb47e05a44cd80a4ce77394d1ac0f79dbd2dd90a69a3a049", size = 148580, upload-time = "2025-08-09T07:56:46.684Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/61/19b36f4bd67f2793ab6a99b979b4e4f3d8fc754cbdffb805335df4337126/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:53cd68b185d98dde4ad8990e56a58dea83a4162161b1ea9272e5c9182ce415e0", size = 159870, upload-time = "2025-08-09T07:56:47.941Z" },
+    { url = "https://files.pythonhosted.org/packages/06/57/84722eefdd338c04cf3030ada66889298eaedf3e7a30a624201e0cbe424a/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:30a96e1e1f865f78b030d65241c1ee850cdf422d869e9028e2fc1d5e4db73b92", size = 157797, upload-time = "2025-08-09T07:56:49.756Z" },
+    { url = "https://files.pythonhosted.org/packages/72/2a/aff5dd112b2f14bcc3462c312dce5445806bfc8ab3a7328555da95330e4b/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d716a916938e03231e86e43782ca7878fb602a125a91e7acb8b5112e2e96ac16", size = 152224, upload-time = "2025-08-09T07:56:51.369Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8c/9839225320046ed279c6e839d51f028342eb77c91c89b8ef2549f951f3ec/charset_normalizer-3.4.3-cp314-cp314-win32.whl", hash = "sha256:c6dbd0ccdda3a2ba7c2ecd9d77b37f3b5831687d8dc1b6ca5f56a4880cc7b7ce", size = 100086, upload-time = "2025-08-09T07:56:52.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7a/36fbcf646e41f710ce0a563c1c9a343c6edf9be80786edeb15b6f62e17db/charset_normalizer-3.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:73dc19b562516fc9bcf6e5d6e596df0b4eb98d87e4f79f3ae71840e6ed21361c", size = 107400, upload-time = "2025-08-09T07:56:55.172Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175, upload-time = "2025-08-09T07:57:26.864Z" },
 ]
 
 [[package]]
@@ -307,55 +316,55 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.10.3"
+version = "7.10.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/2c/253cc41cd0f40b84c1c34c5363e0407d73d4a1cae005fed6db3b823175bd/coverage-7.10.3.tar.gz", hash = "sha256:812ba9250532e4a823b070b0420a36499859542335af3dca8f47fc6aa1a05619", size = 822936, upload-time = "2025-08-10T21:27:39.968Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/83/153f54356c7c200013a752ce1ed5448573dca546ce125801afca9e1ac1a4/coverage-7.10.5.tar.gz", hash = "sha256:f2e57716a78bc3ae80b2207be0709a3b2b63b9f2dcf9740ee6ac03588a2015b6", size = 821662, upload-time = "2025-08-23T14:42:44.78Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/ff/239e4de9cc149c80e9cc359fab60592365b8c4cbfcad58b8a939d18c6898/coverage-7.10.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b99e87304ffe0eb97c5308447328a584258951853807afdc58b16143a530518a", size = 216298, upload-time = "2025-08-10T21:26:10.973Z" },
-    { url = "https://files.pythonhosted.org/packages/56/da/28717da68f8ba68f14b9f558aaa8f3e39ada8b9a1ae4f4977c8f98b286d5/coverage-7.10.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4af09c7574d09afbc1ea7da9dcea23665c01f3bc1b1feb061dac135f98ffc53a", size = 216546, upload-time = "2025-08-10T21:26:12.616Z" },
-    { url = "https://files.pythonhosted.org/packages/de/bb/e1ade16b9e3f2d6c323faeb6bee8e6c23f3a72760a5d9af102ef56a656cb/coverage-7.10.3-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:488e9b50dc5d2aa9521053cfa706209e5acf5289e81edc28291a24f4e4488f46", size = 247538, upload-time = "2025-08-10T21:26:14.455Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/2f/6ae1db51dc34db499bfe340e89f79a63bd115fc32513a7bacdf17d33cd86/coverage-7.10.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:913ceddb4289cbba3a310704a424e3fb7aac2bc0c3a23ea473193cb290cf17d4", size = 250141, upload-time = "2025-08-10T21:26:15.787Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/ed/33efd8819895b10c66348bf26f011dd621e804866c996ea6893d682218df/coverage-7.10.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b1f91cbc78c7112ab84ed2a8defbccd90f888fcae40a97ddd6466b0bec6ae8a", size = 251415, upload-time = "2025-08-10T21:26:17.535Z" },
-    { url = "https://files.pythonhosted.org/packages/26/04/cb83826f313d07dc743359c9914d9bc460e0798da9a0e38b4f4fabc207ed/coverage-7.10.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0bac054d45af7cd938834b43a9878b36ea92781bcb009eab040a5b09e9927e3", size = 249575, upload-time = "2025-08-10T21:26:18.921Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/fd/ae963c7a8e9581c20fa4355ab8940ca272554d8102e872dbb932a644e410/coverage-7.10.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:fe72cbdd12d9e0f4aca873fa6d755e103888a7f9085e4a62d282d9d5b9f7928c", size = 247466, upload-time = "2025-08-10T21:26:20.263Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e8/b68d1487c6af370b8d5ef223c6d7e250d952c3acfbfcdbf1a773aa0da9d2/coverage-7.10.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c1e2e927ab3eadd7c244023927d646e4c15c65bb2ac7ae3c3e9537c013700d21", size = 249084, upload-time = "2025-08-10T21:26:21.638Z" },
-    { url = "https://files.pythonhosted.org/packages/66/4d/a0bcb561645c2c1e21758d8200443669d6560d2a2fb03955291110212ec4/coverage-7.10.3-cp313-cp313-win32.whl", hash = "sha256:24d0c13de473b04920ddd6e5da3c08831b1170b8f3b17461d7429b61cad59ae0", size = 218735, upload-time = "2025-08-10T21:26:23.009Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c3/78b4adddbc0feb3b223f62761e5f9b4c5a758037aaf76e0a5845e9e35e48/coverage-7.10.3-cp313-cp313-win_amd64.whl", hash = "sha256:3564aae76bce4b96e2345cf53b4c87e938c4985424a9be6a66ee902626edec4c", size = 219531, upload-time = "2025-08-10T21:26:24.474Z" },
-    { url = "https://files.pythonhosted.org/packages/70/1b/1229c0b2a527fa5390db58d164aa896d513a1fbb85a1b6b6676846f00552/coverage-7.10.3-cp313-cp313-win_arm64.whl", hash = "sha256:f35580f19f297455f44afcd773c9c7a058e52eb6eb170aa31222e635f2e38b87", size = 218162, upload-time = "2025-08-10T21:26:25.847Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/26/1c1f450e15a3bf3eaecf053ff64538a2612a23f05b21d79ce03be9ff5903/coverage-7.10.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:07009152f497a0464ffdf2634586787aea0e69ddd023eafb23fc38267db94b84", size = 217003, upload-time = "2025-08-10T21:26:27.231Z" },
-    { url = "https://files.pythonhosted.org/packages/29/96/4b40036181d8c2948454b458750960956a3c4785f26a3c29418bbbee1666/coverage-7.10.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8dd2ba5f0c7e7e8cc418be2f0c14c4d9e3f08b8fb8e4c0f83c2fe87d03eb655e", size = 217238, upload-time = "2025-08-10T21:26:28.83Z" },
-    { url = "https://files.pythonhosted.org/packages/62/23/8dfc52e95da20957293fb94d97397a100e63095ec1e0ef5c09dd8c6f591a/coverage-7.10.3-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1ae22b97003c74186e034a93e4f946c75fad8c0ce8d92fbbc168b5e15ee2841f", size = 258561, upload-time = "2025-08-10T21:26:30.475Z" },
-    { url = "https://files.pythonhosted.org/packages/59/95/00e7fcbeda3f632232f4c07dde226afe3511a7781a000aa67798feadc535/coverage-7.10.3-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eb329f1046888a36b1dc35504d3029e1dd5afe2196d94315d18c45ee380f67d5", size = 260735, upload-time = "2025-08-10T21:26:32.333Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/4c/f4666cbc4571804ba2a65b078ff0de600b0b577dc245389e0bc9b69ae7ca/coverage-7.10.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce01048199a91f07f96ca3074b0c14021f4fe7ffd29a3e6a188ac60a5c3a4af8", size = 262960, upload-time = "2025-08-10T21:26:33.701Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/a5/8a9e8a7b12a290ed98b60f73d1d3e5e9ced75a4c94a0d1a671ce3ddfff2a/coverage-7.10.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:08b989a06eb9dfacf96d42b7fb4c9a22bafa370d245dc22fa839f2168c6f9fa1", size = 260515, upload-time = "2025-08-10T21:26:35.16Z" },
-    { url = "https://files.pythonhosted.org/packages/86/11/bb59f7f33b2cac0c5b17db0d9d0abba9c90d9eda51a6e727b43bd5fce4ae/coverage-7.10.3-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:669fe0d4e69c575c52148511029b722ba8d26e8a3129840c2ce0522e1452b256", size = 258278, upload-time = "2025-08-10T21:26:36.539Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/22/3646f8903743c07b3e53fded0700fed06c580a980482f04bf9536657ac17/coverage-7.10.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3262d19092771c83f3413831d9904b1ccc5f98da5de4ffa4ad67f5b20c7aaf7b", size = 259408, upload-time = "2025-08-10T21:26:37.954Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/5c/6375e9d905da22ddea41cd85c30994b8b6f6c02e44e4c5744b76d16b026f/coverage-7.10.3-cp313-cp313t-win32.whl", hash = "sha256:cc0ee4b2ccd42cab7ee6be46d8a67d230cb33a0a7cd47a58b587a7063b6c6b0e", size = 219396, upload-time = "2025-08-10T21:26:39.426Z" },
-    { url = "https://files.pythonhosted.org/packages/33/3b/7da37fd14412b8c8b6e73c3e7458fef6b1b05a37f990a9776f88e7740c89/coverage-7.10.3-cp313-cp313t-win_amd64.whl", hash = "sha256:03db599f213341e2960430984e04cf35fb179724e052a3ee627a068653cf4a7c", size = 220458, upload-time = "2025-08-10T21:26:40.905Z" },
-    { url = "https://files.pythonhosted.org/packages/28/cc/59a9a70f17edab513c844ee7a5c63cf1057041a84cc725b46a51c6f8301b/coverage-7.10.3-cp313-cp313t-win_arm64.whl", hash = "sha256:46eae7893ba65f53c71284585a262f083ef71594f05ec5c85baf79c402369098", size = 218722, upload-time = "2025-08-10T21:26:42.362Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/84/bb773b51a06edbf1231b47dc810a23851f2796e913b335a0fa364773b842/coverage-7.10.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:bce8b8180912914032785850d8f3aacb25ec1810f5f54afc4a8b114e7a9b55de", size = 216280, upload-time = "2025-08-10T21:26:44.132Z" },
-    { url = "https://files.pythonhosted.org/packages/92/a8/4d8ca9c111d09865f18d56facff64d5fa076a5593c290bd1cfc5dceb8dba/coverage-7.10.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:07790b4b37d56608536f7c1079bd1aa511567ac2966d33d5cec9cf520c50a7c8", size = 216557, upload-time = "2025-08-10T21:26:45.598Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/b2/eb668bfc5060194bc5e1ccd6f664e8e045881cfee66c42a2aa6e6c5b26e8/coverage-7.10.3-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e79367ef2cd9166acedcbf136a458dfe9a4a2dd4d1ee95738fb2ee581c56f667", size = 247598, upload-time = "2025-08-10T21:26:47.081Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/b0/9faa4ac62c8822219dd83e5d0e73876398af17d7305968aed8d1606d1830/coverage-7.10.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:419d2a0f769f26cb1d05e9ccbc5eab4cb5d70231604d47150867c07822acbdf4", size = 250131, upload-time = "2025-08-10T21:26:48.65Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/90/203537e310844d4bf1bdcfab89c1e05c25025c06d8489b9e6f937ad1a9e2/coverage-7.10.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee221cf244757cdc2ac882e3062ab414b8464ad9c884c21e878517ea64b3fa26", size = 251485, upload-time = "2025-08-10T21:26:50.368Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/b2/9d894b26bc53c70a1fe503d62240ce6564256d6d35600bdb86b80e516e7d/coverage-7.10.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c2079d8cdd6f7373d628e14b3357f24d1db02c9dc22e6a007418ca7a2be0435a", size = 249488, upload-time = "2025-08-10T21:26:52.045Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/28/af167dbac5281ba6c55c933a0ca6675d68347d5aee39cacc14d44150b922/coverage-7.10.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bd8df1f83c0703fa3ca781b02d36f9ec67ad9cb725b18d486405924f5e4270bd", size = 247419, upload-time = "2025-08-10T21:26:53.533Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/1c/9a4ddc9f0dcb150d4cd619e1c4bb39bcf694c6129220bdd1e5895d694dda/coverage-7.10.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6b4e25e0fa335c8aa26e42a52053f3786a61cc7622b4d54ae2dad994aa754fec", size = 248917, upload-time = "2025-08-10T21:26:55.11Z" },
-    { url = "https://files.pythonhosted.org/packages/92/27/c6a60c7cbe10dbcdcd7fc9ee89d531dc04ea4c073800279bb269954c5a9f/coverage-7.10.3-cp314-cp314-win32.whl", hash = "sha256:d7c3d02c2866deb217dce664c71787f4b25420ea3eaf87056f44fb364a3528f5", size = 218999, upload-time = "2025-08-10T21:26:56.637Z" },
-    { url = "https://files.pythonhosted.org/packages/36/09/a94c1369964ab31273576615d55e7d14619a1c47a662ed3e2a2fe4dee7d4/coverage-7.10.3-cp314-cp314-win_amd64.whl", hash = "sha256:9c8916d44d9e0fe6cdb2227dc6b0edd8bc6c8ef13438bbbf69af7482d9bb9833", size = 219801, upload-time = "2025-08-10T21:26:58.207Z" },
-    { url = "https://files.pythonhosted.org/packages/23/59/f5cd2a80f401c01cf0f3add64a7b791b7d53fd6090a4e3e9ea52691cf3c4/coverage-7.10.3-cp314-cp314-win_arm64.whl", hash = "sha256:1007d6a2b3cf197c57105cc1ba390d9ff7f0bee215ced4dea530181e49c65ab4", size = 218381, upload-time = "2025-08-10T21:26:59.707Z" },
-    { url = "https://files.pythonhosted.org/packages/73/3d/89d65baf1ea39e148ee989de6da601469ba93c1d905b17dfb0b83bd39c96/coverage-7.10.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ebc8791d346410d096818788877d675ca55c91db87d60e8f477bd41c6970ffc6", size = 217019, upload-time = "2025-08-10T21:27:01.242Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/7d/d9850230cd9c999ce3a1e600f85c2fff61a81c301334d7a1faa1a5ba19c8/coverage-7.10.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1f4e4d8e75f6fd3c6940ebeed29e3d9d632e1f18f6fb65d33086d99d4d073241", size = 217237, upload-time = "2025-08-10T21:27:03.442Z" },
-    { url = "https://files.pythonhosted.org/packages/36/51/b87002d417202ab27f4a1cd6bd34ee3b78f51b3ddbef51639099661da991/coverage-7.10.3-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:24581ed69f132b6225a31b0228ae4885731cddc966f8a33fe5987288bdbbbd5e", size = 258735, upload-time = "2025-08-10T21:27:05.124Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/02/1f8612bfcb46fc7ca64a353fff1cd4ed932bb6e0b4e0bb88b699c16794b8/coverage-7.10.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ec151569ddfccbf71bac8c422dce15e176167385a00cd86e887f9a80035ce8a5", size = 260901, upload-time = "2025-08-10T21:27:06.68Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/3a/fe39e624ddcb2373908bd922756384bb70ac1c5009b0d1674eb326a3e428/coverage-7.10.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2ae8e7c56290b908ee817200c0b65929b8050bc28530b131fe7c6dfee3e7d86b", size = 263157, upload-time = "2025-08-10T21:27:08.398Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/89/496b6d5a10fa0d0691a633bb2b2bcf4f38f0bdfcbde21ad9e32d1af328ed/coverage-7.10.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fb742309766d7e48e9eb4dc34bc95a424707bc6140c0e7d9726e794f11b92a0", size = 260597, upload-time = "2025-08-10T21:27:10.237Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/a6/8b5bf6a9e8c6aaeb47d5fe9687014148efc05c3588110246d5fdeef9b492/coverage-7.10.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c65e2a5b32fbe1e499f1036efa6eb9cb4ea2bf6f7168d0e7a5852f3024f471b1", size = 258353, upload-time = "2025-08-10T21:27:11.773Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/6d/ad131be74f8afd28150a07565dfbdc86592fd61d97e2dc83383d9af219f0/coverage-7.10.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d48d2cb07d50f12f4f18d2bb75d9d19e3506c26d96fffabf56d22936e5ed8f7c", size = 259504, upload-time = "2025-08-10T21:27:13.254Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/30/fc9b5097092758cba3375a8cc4ff61774f8cd733bcfb6c9d21a60077a8d8/coverage-7.10.3-cp314-cp314t-win32.whl", hash = "sha256:dec0d9bc15ee305e09fe2cd1911d3f0371262d3cfdae05d79515d8cb712b4869", size = 219782, upload-time = "2025-08-10T21:27:14.736Z" },
-    { url = "https://files.pythonhosted.org/packages/72/9b/27fbf79451b1fac15c4bda6ec6e9deae27cf7c0648c1305aa21a3454f5c4/coverage-7.10.3-cp314-cp314t-win_amd64.whl", hash = "sha256:424ea93a323aa0f7f01174308ea78bde885c3089ec1bef7143a6d93c3e24ef64", size = 220898, upload-time = "2025-08-10T21:27:16.297Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/cf/a32bbf92869cbf0b7c8b84325327bfc718ad4b6d2c63374fef3d58e39306/coverage-7.10.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f5983c132a62d93d71c9ef896a0b9bf6e6828d8d2ea32611f58684fba60bba35", size = 218922, upload-time = "2025-08-10T21:27:18.22Z" },
-    { url = "https://files.pythonhosted.org/packages/84/19/e67f4ae24e232c7f713337f3f4f7c9c58afd0c02866fb07c7b9255a19ed7/coverage-7.10.3-py3-none-any.whl", hash = "sha256:416a8d74dc0adfd33944ba2f405897bab87b7e9e84a391e09d241956bd953ce1", size = 207921, upload-time = "2025-08-10T21:27:38.254Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/08/4166ecfb60ba011444f38a5a6107814b80c34c717bc7a23be0d22e92ca09/coverage-7.10.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ef3b83594d933020f54cf65ea1f4405d1f4e41a009c46df629dd964fcb6e907c", size = 217106, upload-time = "2025-08-23T14:41:15.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d7/b71022408adbf040a680b8c64bf6ead3be37b553e5844f7465643979f7ca/coverage-7.10.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2b96bfdf7c0ea9faebce088a3ecb2382819da4fbc05c7b80040dbc428df6af44", size = 217353, upload-time = "2025-08-23T14:41:16.656Z" },
+    { url = "https://files.pythonhosted.org/packages/74/68/21e0d254dbf8972bb8dd95e3fe7038f4be037ff04ba47d6d1b12b37510ba/coverage-7.10.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:63df1fdaffa42d914d5c4d293e838937638bf75c794cf20bee12978fc8c4e3bc", size = 248350, upload-time = "2025-08-23T14:41:18.128Z" },
+    { url = "https://files.pythonhosted.org/packages/90/65/28752c3a896566ec93e0219fc4f47ff71bd2b745f51554c93e8dcb659796/coverage-7.10.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8002dc6a049aac0e81ecec97abfb08c01ef0c1fbf962d0c98da3950ace89b869", size = 250955, upload-time = "2025-08-23T14:41:19.577Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/ca6b7967f57f6fef31da8749ea20417790bb6723593c8cd98a987be20423/coverage-7.10.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63d4bb2966d6f5f705a6b0c6784c8969c468dbc4bcf9d9ded8bff1c7e092451f", size = 252230, upload-time = "2025-08-23T14:41:20.959Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/29/17a411b2a2a18f8b8c952aa01c00f9284a1fbc677c68a0003b772ea89104/coverage-7.10.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1f672efc0731a6846b157389b6e6d5d5e9e59d1d1a23a5c66a99fd58339914d5", size = 250387, upload-time = "2025-08-23T14:41:22.644Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/89/97a9e271188c2fbb3db82235c33980bcbc733da7da6065afbaa1d685a169/coverage-7.10.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:3f39cef43d08049e8afc1fde4a5da8510fc6be843f8dea350ee46e2a26b2f54c", size = 248280, upload-time = "2025-08-23T14:41:24.061Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/0ad7d0137257553eb4706b4ad6180bec0a1b6a648b092c5bbda48d0e5b2c/coverage-7.10.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2968647e3ed5a6c019a419264386b013979ff1fb67dd11f5c9886c43d6a31fc2", size = 249894, upload-time = "2025-08-23T14:41:26.165Z" },
+    { url = "https://files.pythonhosted.org/packages/84/56/fb3aba936addb4c9e5ea14f5979393f1c2466b4c89d10591fd05f2d6b2aa/coverage-7.10.5-cp313-cp313-win32.whl", hash = "sha256:0d511dda38595b2b6934c2b730a1fd57a3635c6aa2a04cb74714cdfdd53846f4", size = 219536, upload-time = "2025-08-23T14:41:27.694Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/54/baacb8f2f74431e3b175a9a2881feaa8feb6e2f187a0e7e3046f3c7742b2/coverage-7.10.5-cp313-cp313-win_amd64.whl", hash = "sha256:9a86281794a393513cf117177fd39c796b3f8e3759bb2764259a2abba5cce54b", size = 220330, upload-time = "2025-08-23T14:41:29.081Z" },
+    { url = "https://files.pythonhosted.org/packages/64/8a/82a3788f8e31dee51d350835b23d480548ea8621f3effd7c3ba3f7e5c006/coverage-7.10.5-cp313-cp313-win_arm64.whl", hash = "sha256:cebd8e906eb98bb09c10d1feed16096700b1198d482267f8bf0474e63a7b8d84", size = 218961, upload-time = "2025-08-23T14:41:30.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a1/590154e6eae07beee3b111cc1f907c30da6fc8ce0a83ef756c72f3c7c748/coverage-7.10.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0520dff502da5e09d0d20781df74d8189ab334a1e40d5bafe2efaa4158e2d9e7", size = 217819, upload-time = "2025-08-23T14:41:31.962Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ff/436ffa3cfc7741f0973c5c89405307fe39b78dcf201565b934e6616fc4ad/coverage-7.10.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d9cd64aca68f503ed3f1f18c7c9174cbb797baba02ca8ab5112f9d1c0328cd4b", size = 218040, upload-time = "2025-08-23T14:41:33.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ca/5787fb3d7820e66273913affe8209c534ca11241eb34ee8c4fd2aaa9dd87/coverage-7.10.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0913dd1613a33b13c4f84aa6e3f4198c1a21ee28ccb4f674985c1f22109f0aae", size = 259374, upload-time = "2025-08-23T14:41:34.914Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/89/21af956843896adc2e64fc075eae3c1cadb97ee0a6960733e65e696f32dd/coverage-7.10.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1b7181c0feeb06ed8a02da02792f42f829a7b29990fef52eff257fef0885d760", size = 261551, upload-time = "2025-08-23T14:41:36.333Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/96/390a69244ab837e0ac137989277879a084c786cf036c3c4a3b9637d43a89/coverage-7.10.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36d42b7396b605f774d4372dd9c49bed71cbabce4ae1ccd074d155709dd8f235", size = 263776, upload-time = "2025-08-23T14:41:38.25Z" },
+    { url = "https://files.pythonhosted.org/packages/00/32/cfd6ae1da0a521723349f3129b2455832fc27d3f8882c07e5b6fefdd0da2/coverage-7.10.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b4fdc777e05c4940b297bf47bf7eedd56a39a61dc23ba798e4b830d585486ca5", size = 261326, upload-time = "2025-08-23T14:41:40.343Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c4/bf8d459fb4ce2201e9243ce6c015936ad283a668774430a3755f467b39d1/coverage-7.10.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:42144e8e346de44a6f1dbd0a56575dd8ab8dfa7e9007da02ea5b1c30ab33a7db", size = 259090, upload-time = "2025-08-23T14:41:42.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/5d/a234f7409896468e5539d42234016045e4015e857488b0b5b5f3f3fa5f2b/coverage-7.10.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:66c644cbd7aed8fe266d5917e2c9f65458a51cfe5eeff9c05f15b335f697066e", size = 260217, upload-time = "2025-08-23T14:41:43.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/87560f036099f46c2ddd235be6476dd5c1d6be6bb57569a9348d43eeecea/coverage-7.10.5-cp313-cp313t-win32.whl", hash = "sha256:2d1b73023854068c44b0c554578a4e1ef1b050ed07cf8b431549e624a29a66ee", size = 220194, upload-time = "2025-08-23T14:41:45.051Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a8/04a482594fdd83dc677d4a6c7e2d62135fff5a1573059806b8383fad9071/coverage-7.10.5-cp313-cp313t-win_amd64.whl", hash = "sha256:54a1532c8a642d8cc0bd5a9a51f5a9dcc440294fd06e9dda55e743c5ec1a8f14", size = 221258, upload-time = "2025-08-23T14:41:46.44Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ad/7da28594ab66fe2bc720f1bc9b131e62e9b4c6e39f044d9a48d18429cc21/coverage-7.10.5-cp313-cp313t-win_arm64.whl", hash = "sha256:74d5b63fe3f5f5d372253a4ef92492c11a4305f3550631beaa432fc9df16fcff", size = 219521, upload-time = "2025-08-23T14:41:47.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7f/c8b6e4e664b8a95254c35a6c8dd0bf4db201ec681c169aae2f1256e05c85/coverage-7.10.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:68c5e0bc5f44f68053369fa0d94459c84548a77660a5f2561c5e5f1e3bed7031", size = 217090, upload-time = "2025-08-23T14:41:49.327Z" },
+    { url = "https://files.pythonhosted.org/packages/44/74/3ee14ede30a6e10a94a104d1d0522d5fb909a7c7cac2643d2a79891ff3b9/coverage-7.10.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cf33134ffae93865e32e1e37df043bef15a5e857d8caebc0099d225c579b0fa3", size = 217365, upload-time = "2025-08-23T14:41:50.796Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/06ac21bf87dfb7620d1f870dfa3c2cae1186ccbcdc50b8b36e27a0d52f50/coverage-7.10.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ad8fa9d5193bafcf668231294241302b5e683a0518bf1e33a9a0dfb142ec3031", size = 248413, upload-time = "2025-08-23T14:41:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/21/bc/cc5bed6e985d3a14228539631573f3863be6a2587381e8bc5fdf786377a1/coverage-7.10.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:146fa1531973d38ab4b689bc764592fe6c2f913e7e80a39e7eeafd11f0ef6db2", size = 250943, upload-time = "2025-08-23T14:41:53.922Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/43/6a9fc323c2c75cd80b18d58db4a25dc8487f86dd9070f9592e43e3967363/coverage-7.10.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6013a37b8a4854c478d3219ee8bc2392dea51602dd0803a12d6f6182a0061762", size = 252301, upload-time = "2025-08-23T14:41:56.528Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7c/3e791b8845f4cd515275743e3775adb86273576596dc9f02dca37357b4f2/coverage-7.10.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:eb90fe20db9c3d930fa2ad7a308207ab5b86bf6a76f54ab6a40be4012d88fcae", size = 250302, upload-time = "2025-08-23T14:41:58.171Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bc/5099c1e1cb0c9ac6491b281babea6ebbf999d949bf4aa8cdf4f2b53505e8/coverage-7.10.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:384b34482272e960c438703cafe63316dfbea124ac62006a455c8410bf2a2262", size = 248237, upload-time = "2025-08-23T14:41:59.703Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/51/d346eb750a0b2f1e77f391498b753ea906fde69cc11e4b38dca28c10c88c/coverage-7.10.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:467dc74bd0a1a7de2bedf8deaf6811f43602cb532bd34d81ffd6038d6d8abe99", size = 249726, upload-time = "2025-08-23T14:42:01.343Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/85/eebcaa0edafe427e93286b94f56ea7e1280f2c49da0a776a6f37e04481f9/coverage-7.10.5-cp314-cp314-win32.whl", hash = "sha256:556d23d4e6393ca898b2e63a5bca91e9ac2d5fb13299ec286cd69a09a7187fde", size = 219825, upload-time = "2025-08-23T14:42:03.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f7/6d43e037820742603f1e855feb23463979bf40bd27d0cde1f761dcc66a3e/coverage-7.10.5-cp314-cp314-win_amd64.whl", hash = "sha256:f4446a9547681533c8fa3e3c6cf62121eeee616e6a92bd9201c6edd91beffe13", size = 220618, upload-time = "2025-08-23T14:42:05.037Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b0/ed9432e41424c51509d1da603b0393404b828906236fb87e2c8482a93468/coverage-7.10.5-cp314-cp314-win_arm64.whl", hash = "sha256:5e78bd9cf65da4c303bf663de0d73bf69f81e878bf72a94e9af67137c69b9fe9", size = 219199, upload-time = "2025-08-23T14:42:06.662Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/54/5a7ecfa77910f22b659c820f67c16fc1e149ed132ad7117f0364679a8fa9/coverage-7.10.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:5661bf987d91ec756a47c7e5df4fbcb949f39e32f9334ccd3f43233bbb65e508", size = 217833, upload-time = "2025-08-23T14:42:08.262Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0e/25672d917cc57857d40edf38f0b867fb9627115294e4f92c8fcbbc18598d/coverage-7.10.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a46473129244db42a720439a26984f8c6f834762fc4573616c1f37f13994b357", size = 218048, upload-time = "2025-08-23T14:42:10.247Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7c/0b2b4f1c6f71885d4d4b2b8608dcfc79057adb7da4143eb17d6260389e42/coverage-7.10.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1f64b8d3415d60f24b058b58d859e9512624bdfa57a2d1f8aff93c1ec45c429b", size = 259549, upload-time = "2025-08-23T14:42:11.811Z" },
+    { url = "https://files.pythonhosted.org/packages/94/73/abb8dab1609abec7308d83c6aec547944070526578ee6c833d2da9a0ad42/coverage-7.10.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:44d43de99a9d90b20e0163f9770542357f58860a26e24dc1d924643bd6aa7cb4", size = 261715, upload-time = "2025-08-23T14:42:13.505Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d1/abf31de21ec92731445606b8d5e6fa5144653c2788758fcf1f47adb7159a/coverage-7.10.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a931a87e5ddb6b6404e65443b742cb1c14959622777f2a4efd81fba84f5d91ba", size = 263969, upload-time = "2025-08-23T14:42:15.422Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b3/ef274927f4ebede96056173b620db649cc9cb746c61ffc467946b9d0bc67/coverage-7.10.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f9559b906a100029274448f4c8b8b0a127daa4dade5661dfd821b8c188058842", size = 261408, upload-time = "2025-08-23T14:42:16.971Z" },
+    { url = "https://files.pythonhosted.org/packages/20/fc/83ca2812be616d69b4cdd4e0c62a7bc526d56875e68fd0f79d47c7923584/coverage-7.10.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b08801e25e3b4526ef9ced1aa29344131a8f5213c60c03c18fe4c6170ffa2874", size = 259168, upload-time = "2025-08-23T14:42:18.512Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/4f/e0779e5716f72d5c9962e709d09815d02b3b54724e38567308304c3fc9df/coverage-7.10.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed9749bb8eda35f8b636fb7632f1c62f735a236a5d4edadd8bbcc5ea0542e732", size = 260317, upload-time = "2025-08-23T14:42:20.005Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/fe/4247e732f2234bb5eb9984a0888a70980d681f03cbf433ba7b48f08ca5d5/coverage-7.10.5-cp314-cp314t-win32.whl", hash = "sha256:609b60d123fc2cc63ccee6d17e4676699075db72d14ac3c107cc4976d516f2df", size = 220600, upload-time = "2025-08-23T14:42:22.027Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/a0/f294cff6d1034b87839987e5b6ac7385bec599c44d08e0857ac7f164ad0c/coverage-7.10.5-cp314-cp314t-win_amd64.whl", hash = "sha256:0666cf3d2c1626b5a3463fd5b05f5e21f99e6aec40a3192eee4d07a15970b07f", size = 221714, upload-time = "2025-08-23T14:42:23.616Z" },
+    { url = "https://files.pythonhosted.org/packages/23/18/fa1afdc60b5528d17416df440bcbd8fd12da12bfea9da5b6ae0f7a37d0f7/coverage-7.10.5-cp314-cp314t-win_arm64.whl", hash = "sha256:bc85eb2d35e760120540afddd3044a5bf69118a91a296a8b3940dfc4fdcfe1e2", size = 219735, upload-time = "2025-08-23T14:42:25.156Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b6/fff6609354deba9aeec466e4bcaeb9d1ed3e5d60b14b57df2a36fb2273f2/coverage-7.10.5-py3-none-any.whl", hash = "sha256:0be24d35e4db1d23d0db5c0f6a74a962e2ec83c426b5cac09f4234aadef38e4a", size = 208736, upload-time = "2025-08-23T14:42:43.145Z" },
 ]
 
 [[package]]
@@ -659,6 +668,7 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
     { name = "uvloop" },
+    { name = "xxhash" },
 ]
 
 [package.dev-dependencies]
@@ -672,6 +682,7 @@ dev = [
     { name = "filelock" },
     { name = "lint" },
     { name = "mypy" },
+    { name = "openapi-python-client" },
     { name = "oscrypto" },
     { name = "prometheus-client" },
     { name = "pytest" },
@@ -718,6 +729,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "urllib3", specifier = ">=2.0.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
+    { name = "xxhash", specifier = ">=3.5.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -731,6 +743,7 @@ dev = [
     { name = "filelock", specifier = ">=3.19.1" },
     { name = "lint", specifier = ">=1.2.1" },
     { name = "mypy", specifier = ">=1.8.0" },
+    { name = "openapi-python-client", git = "https://github.com/phihos/openapi-python-client?branch=enumerate-duplicate-model-names" },
     { name = "oscrypto", git = "https://github.com/wbond/oscrypto.git?rev=d5f3437" },
     { name = "prometheus-client", specifier = ">=0.22.1" },
     { name = "pytest", specifier = ">=8.4.1" },
@@ -996,47 +1009,47 @@ wheels = [
 
 [[package]]
 name = "multidict"
-version = "6.6.3"
+version = "6.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3d/2c/5dad12e82fbdf7470f29bff2171484bf07cb3b16ada60a6589af8f376440/multidict-6.6.3.tar.gz", hash = "sha256:798a9eb12dab0a6c2e29c1de6f3468af5cb2da6053a20dfa3344907eed0937cc", size = 101006, upload-time = "2025-06-30T15:53:46.929Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/7f/0652e6ed47ab288e3756ea9c0df8b14950781184d4bd7883f4d87dd41245/multidict-6.6.4.tar.gz", hash = "sha256:d2d4e4787672911b48350df02ed3fa3fffdc2f2e8ca06dd6afdf34189b76a9dd", size = 101843, upload-time = "2025-08-11T12:08:48.217Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/1d/0bebcbbb4f000751fbd09957257903d6e002943fc668d841a4cf2fb7f872/multidict-6.6.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:540d3c06d48507357a7d57721e5094b4f7093399a0106c211f33540fdc374d55", size = 75843, upload-time = "2025-06-30T15:52:16.155Z" },
-    { url = "https://files.pythonhosted.org/packages/07/8f/cbe241b0434cfe257f65c2b1bcf9e8d5fb52bc708c5061fb29b0fed22bdf/multidict-6.6.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9c19cea2a690f04247d43f366d03e4eb110a0dc4cd1bbeee4d445435428ed35b", size = 45053, upload-time = "2025-06-30T15:52:17.429Z" },
-    { url = "https://files.pythonhosted.org/packages/32/d2/0b3b23f9dbad5b270b22a3ac3ea73ed0a50ef2d9a390447061178ed6bdb8/multidict-6.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7af039820cfd00effec86bda5d8debef711a3e86a1d3772e85bea0f243a4bd65", size = 43273, upload-time = "2025-06-30T15:52:19.346Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/fe/6eb68927e823999e3683bc49678eb20374ba9615097d085298fd5b386564/multidict-6.6.3-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:500b84f51654fdc3944e936f2922114349bf8fdcac77c3092b03449f0e5bc2b3", size = 237124, upload-time = "2025-06-30T15:52:20.773Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ab/320d8507e7726c460cb77117848b3834ea0d59e769f36fdae495f7669929/multidict-6.6.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f3fc723ab8a5c5ed6c50418e9bfcd8e6dceba6c271cee6728a10a4ed8561520c", size = 256892, upload-time = "2025-06-30T15:52:22.242Z" },
-    { url = "https://files.pythonhosted.org/packages/76/60/38ee422db515ac69834e60142a1a69111ac96026e76e8e9aa347fd2e4591/multidict-6.6.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:94c47ea3ade005b5976789baaed66d4de4480d0a0bf31cef6edaa41c1e7b56a6", size = 240547, upload-time = "2025-06-30T15:52:23.736Z" },
-    { url = "https://files.pythonhosted.org/packages/27/fb/905224fde2dff042b030c27ad95a7ae744325cf54b890b443d30a789b80e/multidict-6.6.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dbc7cf464cc6d67e83e136c9f55726da3a30176f020a36ead246eceed87f1cd8", size = 266223, upload-time = "2025-06-30T15:52:25.185Z" },
-    { url = "https://files.pythonhosted.org/packages/76/35/dc38ab361051beae08d1a53965e3e1a418752fc5be4d3fb983c5582d8784/multidict-6.6.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:900eb9f9da25ada070f8ee4a23f884e0ee66fe4e1a38c3af644256a508ad81ca", size = 267262, upload-time = "2025-06-30T15:52:26.969Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/a3/0a485b7f36e422421b17e2bbb5a81c1af10eac1d4476f2ff92927c730479/multidict-6.6.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c6df517cf177da5d47ab15407143a89cd1a23f8b335f3a28d57e8b0a3dbb884", size = 254345, upload-time = "2025-06-30T15:52:28.467Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/59/bcdd52c1dab7c0e0d75ff19cac751fbd5f850d1fc39172ce809a74aa9ea4/multidict-6.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ef421045f13879e21c994b36e728d8e7d126c91a64b9185810ab51d474f27e7", size = 252248, upload-time = "2025-06-30T15:52:29.938Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/a4/2d96aaa6eae8067ce108d4acee6f45ced5728beda55c0f02ae1072c730d1/multidict-6.6.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:6c1e61bb4f80895c081790b6b09fa49e13566df8fbff817da3f85b3a8192e36b", size = 250115, upload-time = "2025-06-30T15:52:31.416Z" },
-    { url = "https://files.pythonhosted.org/packages/25/d2/ed9f847fa5c7d0677d4f02ea2c163d5e48573de3f57bacf5670e43a5ffaa/multidict-6.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e5e8523bb12d7623cd8300dbd91b9e439a46a028cd078ca695eb66ba31adee3c", size = 249649, upload-time = "2025-06-30T15:52:32.996Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/af/9155850372563fc550803d3f25373308aa70f59b52cff25854086ecb4a79/multidict-6.6.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:ef58340cc896219e4e653dade08fea5c55c6df41bcc68122e3be3e9d873d9a7b", size = 261203, upload-time = "2025-06-30T15:52:34.521Z" },
-    { url = "https://files.pythonhosted.org/packages/36/2f/c6a728f699896252cf309769089568a33c6439626648843f78743660709d/multidict-6.6.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc9dc435ec8699e7b602b94fe0cd4703e69273a01cbc34409af29e7820f777f1", size = 258051, upload-time = "2025-06-30T15:52:35.999Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/60/689880776d6b18fa2b70f6cc74ff87dd6c6b9b47bd9cf74c16fecfaa6ad9/multidict-6.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9e864486ef4ab07db5e9cb997bad2b681514158d6954dd1958dfb163b83d53e6", size = 249601, upload-time = "2025-06-30T15:52:37.473Z" },
-    { url = "https://files.pythonhosted.org/packages/75/5e/325b11f2222a549019cf2ef879c1f81f94a0d40ace3ef55cf529915ba6cc/multidict-6.6.3-cp313-cp313-win32.whl", hash = "sha256:5633a82fba8e841bc5c5c06b16e21529573cd654f67fd833650a215520a6210e", size = 41683, upload-time = "2025-06-30T15:52:38.927Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ad/cf46e73f5d6e3c775cabd2a05976547f3f18b39bee06260369a42501f053/multidict-6.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:e93089c1570a4ad54c3714a12c2cef549dc9d58e97bcded193d928649cab78e9", size = 45811, upload-time = "2025-06-30T15:52:40.207Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/c9/2e3fe950db28fb7c62e1a5f46e1e38759b072e2089209bc033c2798bb5ec/multidict-6.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:c60b401f192e79caec61f166da9c924e9f8bc65548d4246842df91651e83d600", size = 43056, upload-time = "2025-06-30T15:52:41.575Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/58/aaf8114cf34966e084a8cc9517771288adb53465188843d5a19862cb6dc3/multidict-6.6.3-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:02fd8f32d403a6ff13864b0851f1f523d4c988051eea0471d4f1fd8010f11134", size = 82811, upload-time = "2025-06-30T15:52:43.281Z" },
-    { url = "https://files.pythonhosted.org/packages/71/af/5402e7b58a1f5b987a07ad98f2501fdba2a4f4b4c30cf114e3ce8db64c87/multidict-6.6.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:f3aa090106b1543f3f87b2041eef3c156c8da2aed90c63a2fbed62d875c49c37", size = 48304, upload-time = "2025-06-30T15:52:45.026Z" },
-    { url = "https://files.pythonhosted.org/packages/39/65/ab3c8cafe21adb45b24a50266fd747147dec7847425bc2a0f6934b3ae9ce/multidict-6.6.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e924fb978615a5e33ff644cc42e6aa241effcf4f3322c09d4f8cebde95aff5f8", size = 46775, upload-time = "2025-06-30T15:52:46.459Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ba/9fcc1b332f67cc0c0c8079e263bfab6660f87fe4e28a35921771ff3eea0d/multidict-6.6.3-cp313-cp313t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:b9fe5a0e57c6dbd0e2ce81ca66272282c32cd11d31658ee9553849d91289e1c1", size = 229773, upload-time = "2025-06-30T15:52:47.88Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/14/0145a251f555f7c754ce2dcbcd012939bbd1f34f066fa5d28a50e722a054/multidict-6.6.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b24576f208793ebae00280c59927c3b7c2a3b1655e443a25f753c4611bc1c373", size = 250083, upload-time = "2025-06-30T15:52:49.366Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/d4/d5c0bd2bbb173b586c249a151a26d2fb3ec7d53c96e42091c9fef4e1f10c/multidict-6.6.3-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:135631cb6c58eac37d7ac0df380294fecdc026b28837fa07c02e459c7fb9c54e", size = 228980, upload-time = "2025-06-30T15:52:50.903Z" },
-    { url = "https://files.pythonhosted.org/packages/21/32/c9a2d8444a50ec48c4733ccc67254100c10e1c8ae8e40c7a2d2183b59b97/multidict-6.6.3-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:274d416b0df887aef98f19f21578653982cfb8a05b4e187d4a17103322eeaf8f", size = 257776, upload-time = "2025-06-30T15:52:52.764Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d0/14fa1699f4ef629eae08ad6201c6b476098f5efb051b296f4c26be7a9fdf/multidict-6.6.3-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e252017a817fad7ce05cafbe5711ed40faeb580e63b16755a3a24e66fa1d87c0", size = 256882, upload-time = "2025-06-30T15:52:54.596Z" },
-    { url = "https://files.pythonhosted.org/packages/da/88/84a27570fbe303c65607d517a5f147cd2fc046c2d1da02b84b17b9bdc2aa/multidict-6.6.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e4cc8d848cd4fe1cdee28c13ea79ab0ed37fc2e89dd77bac86a2e7959a8c3bc", size = 247816, upload-time = "2025-06-30T15:52:56.175Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/60/dca352a0c999ce96a5d8b8ee0b2b9f729dcad2e0b0c195f8286269a2074c/multidict-6.6.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9e236a7094b9c4c1b7585f6b9cca34b9d833cf079f7e4c49e6a4a6ec9bfdc68f", size = 245341, upload-time = "2025-06-30T15:52:57.752Z" },
-    { url = "https://files.pythonhosted.org/packages/50/ef/433fa3ed06028f03946f3993223dada70fb700f763f70c00079533c34578/multidict-6.6.3-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:e0cb0ab69915c55627c933f0b555a943d98ba71b4d1c57bc0d0a66e2567c7471", size = 235854, upload-time = "2025-06-30T15:52:59.74Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/1f/487612ab56fbe35715320905215a57fede20de7db40a261759690dc80471/multidict-6.6.3-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:81ef2f64593aba09c5212a3d0f8c906a0d38d710a011f2f42759704d4557d3f2", size = 243432, upload-time = "2025-06-30T15:53:01.602Z" },
-    { url = "https://files.pythonhosted.org/packages/da/6f/ce8b79de16cd885c6f9052c96a3671373d00c59b3ee635ea93e6e81b8ccf/multidict-6.6.3-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:b9cbc60010de3562545fa198bfc6d3825df430ea96d2cc509c39bd71e2e7d648", size = 252731, upload-time = "2025-06-30T15:53:03.517Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/fe/a2514a6aba78e5abefa1624ca85ae18f542d95ac5cde2e3815a9fbf369aa/multidict-6.6.3-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:70d974eaaa37211390cd02ef93b7e938de564bbffa866f0b08d07e5e65da783d", size = 247086, upload-time = "2025-06-30T15:53:05.48Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/22/b788718d63bb3cce752d107a57c85fcd1a212c6c778628567c9713f9345a/multidict-6.6.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3713303e4a6663c6d01d648a68f2848701001f3390a030edaaf3fc949c90bf7c", size = 243338, upload-time = "2025-06-30T15:53:07.522Z" },
-    { url = "https://files.pythonhosted.org/packages/22/d6/fdb3d0670819f2228f3f7d9af613d5e652c15d170c83e5f1c94fbc55a25b/multidict-6.6.3-cp313-cp313t-win32.whl", hash = "sha256:639ecc9fe7cd73f2495f62c213e964843826f44505a3e5d82805aa85cac6f89e", size = 47812, upload-time = "2025-06-30T15:53:09.263Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/d6/a9d2c808f2c489ad199723197419207ecbfbc1776f6e155e1ecea9c883aa/multidict-6.6.3-cp313-cp313t-win_amd64.whl", hash = "sha256:9f97e181f344a0ef3881b573d31de8542cc0dbc559ec68c8f8b5ce2c2e91646d", size = 53011, upload-time = "2025-06-30T15:53:11.038Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/40/b68001cba8188dd267590a111f9661b6256debc327137667e832bf5d66e8/multidict-6.6.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ce8b7693da41a3c4fde5871c738a81490cea5496c671d74374c8ab889e1834fb", size = 45254, upload-time = "2025-06-30T15:53:12.421Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/30/9aec301e9772b098c1f5c0ca0279237c9766d94b97802e9888010c64b0ed/multidict-6.6.3-py3-none-any.whl", hash = "sha256:8db10f29c7541fc5da4defd8cd697e1ca429db743fa716325f236079b96f775a", size = 12313, upload-time = "2025-06-30T15:53:45.437Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5d/e1db626f64f60008320aab00fbe4f23fc3300d75892a3381275b3d284580/multidict-6.6.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f46a6e8597f9bd71b31cc708195d42b634c8527fecbcf93febf1052cacc1f16e", size = 75848, upload-time = "2025-08-11T12:07:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/aa/8b6f548d839b6c13887253af4e29c939af22a18591bfb5d0ee6f1931dae8/multidict-6.6.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:22e38b2bc176c5eb9c0a0e379f9d188ae4cd8b28c0f53b52bce7ab0a9e534657", size = 45060, upload-time = "2025-08-11T12:07:21.163Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/c6/f5e97e5d99a729bc2aa58eb3ebfa9f1e56a9b517cc38c60537c81834a73f/multidict-6.6.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5df8afd26f162da59e218ac0eefaa01b01b2e6cd606cffa46608f699539246da", size = 43269, upload-time = "2025-08-11T12:07:22.392Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/31/d54eb0c62516776f36fe67f84a732f97e0b0e12f98d5685bebcc6d396910/multidict-6.6.4-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:49517449b58d043023720aa58e62b2f74ce9b28f740a0b5d33971149553d72aa", size = 237158, upload-time = "2025-08-11T12:07:23.636Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/1c/8a10c1c25b23156e63b12165a929d8eb49a6ed769fdbefb06e6f07c1e50d/multidict-6.6.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae9408439537c5afdca05edd128a63f56a62680f4b3c234301055d7a2000220f", size = 257076, upload-time = "2025-08-11T12:07:25.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/86/90e20b5771d6805a119e483fd3d1e8393e745a11511aebca41f0da38c3e2/multidict-6.6.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:87a32d20759dc52a9e850fe1061b6e41ab28e2998d44168a8a341b99ded1dba0", size = 240694, upload-time = "2025-08-11T12:07:26.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/49/484d3e6b535bc0555b52a0a26ba86e4d8d03fd5587d4936dc59ba7583221/multidict-6.6.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:52e3c8d43cdfff587ceedce9deb25e6ae77daba560b626e97a56ddcad3756879", size = 266350, upload-time = "2025-08-11T12:07:27.94Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b4/aa4c5c379b11895083d50021e229e90c408d7d875471cb3abf721e4670d6/multidict-6.6.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ad8850921d3a8d8ff6fbef790e773cecfc260bbfa0566998980d3fa8f520bc4a", size = 267250, upload-time = "2025-08-11T12:07:29.303Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e5/5e22c5bf96a64bdd43518b1834c6d95a4922cc2066b7d8e467dae9b6cee6/multidict-6.6.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:497a2954adc25c08daff36f795077f63ad33e13f19bfff7736e72c785391534f", size = 254900, upload-time = "2025-08-11T12:07:30.764Z" },
+    { url = "https://files.pythonhosted.org/packages/17/38/58b27fed927c07035abc02befacab42491e7388ca105e087e6e0215ead64/multidict-6.6.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:024ce601f92d780ca1617ad4be5ac15b501cc2414970ffa2bb2bbc2bd5a68fa5", size = 252355, upload-time = "2025-08-11T12:07:32.205Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a1/dad75d23a90c29c02b5d6f3d7c10ab36c3197613be5d07ec49c7791e186c/multidict-6.6.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:a693fc5ed9bdd1c9e898013e0da4dcc640de7963a371c0bd458e50e046bf6438", size = 250061, upload-time = "2025-08-11T12:07:33.623Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/1a/ac2216b61c7f116edab6dc3378cca6c70dc019c9a457ff0d754067c58b20/multidict-6.6.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:190766dac95aab54cae5b152a56520fd99298f32a1266d66d27fdd1b5ac00f4e", size = 249675, upload-time = "2025-08-11T12:07:34.958Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/79/1916af833b800d13883e452e8e0977c065c4ee3ab7a26941fbfdebc11895/multidict-6.6.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:34d8f2a5ffdceab9dcd97c7a016deb2308531d5f0fced2bb0c9e1df45b3363d7", size = 261247, upload-time = "2025-08-11T12:07:36.588Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/65/d1f84fe08ac44a5fc7391cbc20a7cedc433ea616b266284413fd86062f8c/multidict-6.6.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:59e8d40ab1f5a8597abcef00d04845155a5693b5da00d2c93dbe88f2050f2812", size = 257960, upload-time = "2025-08-11T12:07:39.735Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b5/29ec78057d377b195ac2c5248c773703a6b602e132a763e20ec0457e7440/multidict-6.6.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:467fe64138cfac771f0e949b938c2e1ada2b5af22f39692aa9258715e9ea613a", size = 250078, upload-time = "2025-08-11T12:07:41.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/0e/7e79d38f70a872cae32e29b0d77024bef7834b0afb406ddae6558d9e2414/multidict-6.6.4-cp313-cp313-win32.whl", hash = "sha256:14616a30fe6d0a48d0a48d1a633ab3b8bec4cf293aac65f32ed116f620adfd69", size = 41708, upload-time = "2025-08-11T12:07:43.405Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/34/746696dffff742e97cd6a23da953e55d0ea51fa601fa2ff387b3edcfaa2c/multidict-6.6.4-cp313-cp313-win_amd64.whl", hash = "sha256:40cd05eaeb39e2bc8939451f033e57feaa2ac99e07dbca8afe2be450a4a3b6cf", size = 45912, upload-time = "2025-08-11T12:07:45.082Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/87/3bac136181e271e29170d8d71929cdeddeb77f3e8b6a0c08da3a8e9da114/multidict-6.6.4-cp313-cp313-win_arm64.whl", hash = "sha256:f6eb37d511bfae9e13e82cb4d1af36b91150466f24d9b2b8a9785816deb16605", size = 43076, upload-time = "2025-08-11T12:07:46.746Z" },
+    { url = "https://files.pythonhosted.org/packages/64/94/0a8e63e36c049b571c9ae41ee301ada29c3fee9643d9c2548d7d558a1d99/multidict-6.6.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6c84378acd4f37d1b507dfa0d459b449e2321b3ba5f2338f9b085cf7a7ba95eb", size = 82812, upload-time = "2025-08-11T12:07:48.402Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1a/be8e369dfcd260d2070a67e65dd3990dd635cbd735b98da31e00ea84cd4e/multidict-6.6.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0e0558693063c75f3d952abf645c78f3c5dfdd825a41d8c4d8156fc0b0da6e7e", size = 48313, upload-time = "2025-08-11T12:07:49.679Z" },
+    { url = "https://files.pythonhosted.org/packages/26/5a/dd4ade298674b2f9a7b06a32c94ffbc0497354df8285f27317c66433ce3b/multidict-6.6.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3f8e2384cb83ebd23fd07e9eada8ba64afc4c759cd94817433ab8c81ee4b403f", size = 46777, upload-time = "2025-08-11T12:07:51.318Z" },
+    { url = "https://files.pythonhosted.org/packages/89/db/98aa28bc7e071bfba611ac2ae803c24e96dd3a452b4118c587d3d872c64c/multidict-6.6.4-cp313-cp313t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:f996b87b420995a9174b2a7c1a8daf7db4750be6848b03eb5e639674f7963773", size = 229321, upload-time = "2025-08-11T12:07:52.965Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/bc/01ddda2a73dd9d167bd85d0e8ef4293836a8f82b786c63fb1a429bc3e678/multidict-6.6.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc356250cffd6e78416cf5b40dc6a74f1edf3be8e834cf8862d9ed5265cf9b0e", size = 249954, upload-time = "2025-08-11T12:07:54.423Z" },
+    { url = "https://files.pythonhosted.org/packages/06/78/6b7c0f020f9aa0acf66d0ab4eb9f08375bac9a50ff5e3edb1c4ccd59eafc/multidict-6.6.4-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:dadf95aa862714ea468a49ad1e09fe00fcc9ec67d122f6596a8d40caf6cec7d0", size = 228612, upload-time = "2025-08-11T12:07:55.914Z" },
+    { url = "https://files.pythonhosted.org/packages/00/44/3faa416f89b2d5d76e9d447296a81521e1c832ad6e40b92f990697b43192/multidict-6.6.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7dd57515bebffd8ebd714d101d4c434063322e4fe24042e90ced41f18b6d3395", size = 257528, upload-time = "2025-08-11T12:07:57.371Z" },
+    { url = "https://files.pythonhosted.org/packages/05/5f/77c03b89af0fcb16f018f668207768191fb9dcfb5e3361a5e706a11db2c9/multidict-6.6.4-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:967af5f238ebc2eb1da4e77af5492219fbd9b4b812347da39a7b5f5c72c0fa45", size = 256329, upload-time = "2025-08-11T12:07:58.844Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e9/ed750a2a9afb4f8dc6f13dc5b67b514832101b95714f1211cd42e0aafc26/multidict-6.6.4-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a4c6875c37aae9794308ec43e3530e4aa0d36579ce38d89979bbf89582002bb", size = 247928, upload-time = "2025-08-11T12:08:01.037Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/e0571bc13cda277db7e6e8a532791d4403dacc9850006cb66d2556e649c0/multidict-6.6.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:7f683a551e92bdb7fac545b9c6f9fa2aebdeefa61d607510b3533286fcab67f5", size = 245228, upload-time = "2025-08-11T12:08:02.96Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a3/69a84b0eccb9824491f06368f5b86e72e4af54c3067c37c39099b6687109/multidict-6.6.4-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:3ba5aaf600edaf2a868a391779f7a85d93bed147854925f34edd24cc70a3e141", size = 235869, upload-time = "2025-08-11T12:08:04.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/9d/28802e8f9121a6a0804fa009debf4e753d0a59969ea9f70be5f5fdfcb18f/multidict-6.6.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:580b643b7fd2c295d83cad90d78419081f53fd532d1f1eb67ceb7060f61cff0d", size = 243446, upload-time = "2025-08-11T12:08:06.332Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ea/6c98add069b4878c1d66428a5f5149ddb6d32b1f9836a826ac764b9940be/multidict-6.6.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:37b7187197da6af3ee0b044dbc9625afd0c885f2800815b228a0e70f9a7f473d", size = 252299, upload-time = "2025-08-11T12:08:07.931Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/09/8fe02d204473e14c0af3affd50af9078839dfca1742f025cca765435d6b4/multidict-6.6.4-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:e1b93790ed0bc26feb72e2f08299691ceb6da5e9e14a0d13cc74f1869af327a0", size = 246926, upload-time = "2025-08-11T12:08:09.467Z" },
+    { url = "https://files.pythonhosted.org/packages/37/3d/7b1e10d774a6df5175ecd3c92bff069e77bed9ec2a927fdd4ff5fe182f67/multidict-6.6.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a506a77ddee1efcca81ecbeae27ade3e09cdf21a8ae854d766c2bb4f14053f92", size = 243383, upload-time = "2025-08-11T12:08:10.981Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b0/a6fae46071b645ae98786ab738447de1ef53742eaad949f27e960864bb49/multidict-6.6.4-cp313-cp313t-win32.whl", hash = "sha256:f93b2b2279883d1d0a9e1bd01f312d6fc315c5e4c1f09e112e4736e2f650bc4e", size = 47775, upload-time = "2025-08-11T12:08:12.439Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/0a/2436550b1520091af0600dff547913cb2d66fbac27a8c33bc1b1bccd8d98/multidict-6.6.4-cp313-cp313t-win_amd64.whl", hash = "sha256:6d46a180acdf6e87cc41dc15d8f5c2986e1e8739dc25dbb7dac826731ef381a4", size = 53100, upload-time = "2025-08-11T12:08:13.823Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ea/43ac51faff934086db9c072a94d327d71b7d8b40cd5dcb47311330929ef0/multidict-6.6.4-cp313-cp313t-win_arm64.whl", hash = "sha256:756989334015e3335d087a27331659820d53ba432befdef6a718398b0a8493ad", size = 45501, upload-time = "2025-08-11T12:08:15.173Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/69/b547032297c7e63ba2af494edba695d781af8a0c6e89e4d06cf848b21d80/multidict-6.6.4-py3-none-any.whl", hash = "sha256:27d8f8e125c07cb954e54d75d04905a9bba8a439c1d84aca94949d4d03d8601c", size = 12313, upload-time = "2025-08-11T12:08:46.891Z" },
 ]
 
 [[package]]
@@ -1081,6 +1094,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "openapi-python-client"
+version = "0.26.0"
+source = { git = "https://github.com/phihos/openapi-python-client?branch=enumerate-duplicate-model-names#ac4d73985d1e0b38d87027e9fd6c0d5f56ad1319" }
+dependencies = [
+    { name = "attrs" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "ruamel-yaml" },
+    { name = "ruff" },
+    { name = "shellingham" },
+    { name = "typer" },
+    { name = "typing-extensions" },
 ]
 
 [[package]]
@@ -1262,18 +1293,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
-]
-
-[[package]]
-name = "pbr"
-version = "6.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/01/d2/510cc0d218e753ba62a1bc1434651db3cd797a9716a0a66cc714cb4f0935/pbr-6.1.1.tar.gz", hash = "sha256:93ea72ce6989eb2eed99d0f75721474f69ad88128afdef5ac377eb797c4bf76b", size = 125702, upload-time = "2025-02-04T14:28:06.514Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/ac/684d71315abc7b1214d59304e23a982472967f6bf4bde5a98f1503f648dc/pbr-6.1.1-py2.py3-none-any.whl", hash = "sha256:38d4daea5d9fa63b3f626131b9d34947fd0c8be9b05a29276870580050a25a76", size = 108997, upload-time = "2025-02-04T14:28:03.168Z" },
 ]
 
 [[package]]
@@ -1481,7 +1500,7 @@ wheels = [
 
 [[package]]
 name = "pylint"
-version = "3.3.7"
+version = "3.3.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astroid" },
@@ -1492,9 +1511,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/e4/83e487d3ddd64ab27749b66137b26dc0c5b5c161be680e6beffdc99070b3/pylint-3.3.7.tar.gz", hash = "sha256:2b11de8bde49f9c5059452e0c310c079c746a0a8eeaa789e5aa966ecc23e4559", size = 1520709, upload-time = "2025-05-04T17:07:51.089Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/58/1f614a84d3295c542e9f6e2c764533eea3f318f4592dc1ea06c797114767/pylint-3.3.8.tar.gz", hash = "sha256:26698de19941363037e2937d3db9ed94fb3303fdadf7d98847875345a8bb6b05", size = 1523947, upload-time = "2025-08-09T09:12:57.234Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/83/bff755d09e31b5d25cc7fdc4bf3915d1a404e181f1abf0359af376845c24/pylint-3.3.7-py3-none-any.whl", hash = "sha256:43860aafefce92fca4cf6b61fe199cdc5ae54ea28f9bf4cd49de267b5195803d", size = 522565, upload-time = "2025-05-04T17:07:48.714Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/1a/711e93a7ab6c392e349428ea56e794a3902bb4e0284c1997cff2d7efdbc1/pylint-3.3.8-py3-none-any.whl", hash = "sha256:7ef94aa692a600e82fabdd17102b73fc226758218c97473c7ad67bd4cb905d83", size = 523153, upload-time = "2025-08-09T09:12:54.836Z" },
 ]
 
 [[package]]
@@ -1639,11 +1658,11 @@ wheels = [
 
 [[package]]
 name = "python-jsonpath"
-version = "1.3.1"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/99/767bb6fddf6686f6bb5855bc7895b7ccaa50fe92c06eb92f3308a5571787/python_jsonpath-1.3.1.tar.gz", hash = "sha256:90d348be9c6f0ee070cb6419d4b2b08fcbb07f5a2a34060b8833bef024099315", size = 43115, upload-time = "2025-06-22T08:08:38.868Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/96/f9d66dda3ff5d411e87df2fb6a134b652b40905d7fcf9faff9e07582c4d7/python_jsonpath-1.3.2.tar.gz", hash = "sha256:aa76f07f56f93c63a69b6b5d581dbcf2faf908aefbc5c6bcb7bf98bacfb07548", size = 43504, upload-time = "2025-08-15T07:06:16.749Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/ee/ac03351487f22aa7b505185cd53180e82b925c145d96b1ef77d308dcdce4/python_jsonpath-1.3.1-py3-none-any.whl", hash = "sha256:df33fcd56ed6f3eef2eae990b74719c4111f709247ed73cbe1b088063a1aac0c", size = 54435, upload-time = "2025-06-22T08:08:37.357Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/72/d8699ff0cac924ca09bb10d796a828c21e9f0ed656ba9a75f35ad602d87f/python_jsonpath-1.3.2-py3-none-any.whl", hash = "sha256:d4aed27b989a81d4ea9748e040182cc37a6c44c49b7993de2e38594876706cbd", size = 54735, upload-time = "2025-08-15T07:06:14.828Z" },
 ]
 
 [[package]]
@@ -1767,6 +1786,35 @@ wheels = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.18.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.14' and platform_python_implementation == 'CPython'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/db/f3950f5e5031b618aae9f423a39bf81a55c148aecd15a34527898e752cf4/ruamel.yaml-0.18.15.tar.gz", hash = "sha256:dbfca74b018c4c3fba0b9cc9ee33e53c371194a9000e694995e620490fd40700", size = 146865, upload-time = "2025-08-19T11:15:10.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/e5/f2a0621f1781b76a38194acae72f01e37b1941470407345b6e8653ad7640/ruamel.yaml-0.18.15-py3-none-any.whl", hash = "sha256:148f6488d698b7a5eded5ea793a025308b25eca97208181b6a026037f391f701", size = 119702, upload-time = "2025-08-19T11:15:07.696Z" },
+]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/84/80203abff8ea4993a87d823a5f632e4d92831ef75d404c9fc78d0176d2b5/ruamel.yaml.clib-0.2.12.tar.gz", hash = "sha256:6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f", size = 225315, upload-time = "2024-10-20T10:10:56.22Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/00/4864119668d71a5fa45678f380b5923ff410701565821925c69780356ffa/ruamel.yaml.clib-0.2.12-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4c8c5d82f50bb53986a5e02d1b3092b03622c02c2eb78e29bec33fd9593bae1a", size = 132011, upload-time = "2024-10-20T10:13:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5e/212f473a93ae78c669ffa0cb051e3fee1139cb2d385d2ae1653d64281507/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:e7e3736715fbf53e9be2a79eb4db68e4ed857017344d697e8b9749444ae57475", size = 642488, upload-time = "2024-10-20T10:13:05.906Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/8f/ecfbe2123ade605c49ef769788f79c38ddb1c8fa81e01f4dbf5cf1a44b16/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b7e75b4965e1d4690e93021adfcecccbca7d61c7bddd8e22406ef2ff20d74ef", size = 745066, upload-time = "2024-10-20T10:13:07.26Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/28f60726d29dfc01b8decdb385de4ced2ced9faeb37a847bd5cf26836815/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96777d473c05ee3e5e3c3e999f5d23c6f4ec5b0c38c098b3a5229085f74236c6", size = 701785, upload-time = "2024-10-20T10:13:08.504Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7e/8e7ec45920daa7f76046578e4f677a3215fe8f18ee30a9cb7627a19d9b4c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:3bc2a80e6420ca8b7d3590791e2dfc709c88ab9152c00eeb511c9875ce5778bf", size = 693017, upload-time = "2024-10-21T11:26:48.866Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b3/d650eaade4ca225f02a648321e1ab835b9d361c60d51150bac49063b83fa/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e188d2699864c11c36cdfdada94d781fd5d6b0071cd9c427bceb08ad3d7c70e1", size = 741270, upload-time = "2024-10-21T11:26:50.213Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b8/01c29b924dcbbed75cc45b30c30d565d763b9c4d540545a0eeecffb8f09c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f6f3eac23941b32afccc23081e1f50612bdbe4e982012ef4f5797986828cd01", size = 709059, upload-time = "2024-12-11T19:58:18.846Z" },
+    { url = "https://files.pythonhosted.org/packages/30/8c/ed73f047a73638257aa9377ad356bea4d96125b305c34a28766f4445cc0f/ruamel.yaml.clib-0.2.12-cp313-cp313-win32.whl", hash = "sha256:6442cb36270b3afb1b4951f060eccca1ce49f3d087ca1ca4563a6eb479cb3de6", size = 98583, upload-time = "2024-10-20T10:13:09.658Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/85/e8e751d8791564dd333d5d9a4eab0a7a115f7e349595417fd50ecae3395c/ruamel.yaml.clib-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:e5b8daf27af0b90da7bb903a876477a9e6d7270be6146906b276605997c7e9a3", size = 115190, upload-time = "2024-10-20T10:13:10.66Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.12.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1793,12 +1841,12 @@ wheels = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "80.9.0"
+name = "shellingham"
+version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -1830,14 +1878,11 @@ wheels = [
 
 [[package]]
 name = "stevedore"
-version = "5.4.1"
+version = "5.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pbr" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/3f/13cacea96900bbd31bb05c6b74135f85d15564fc583802be56976c940470/stevedore-5.4.1.tar.gz", hash = "sha256:3135b5ae50fe12816ef291baff420acb727fcd356106e3e9cbfa9e5985cd6f4b", size = 513858, upload-time = "2025-02-20T14:03:57.285Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/5f/8418daad5c353300b7661dd8ce2574b0410a6316a8be650a189d5c68d938/stevedore-5.5.0.tar.gz", hash = "sha256:d31496a4f4df9825e1a1e4f1f74d19abb0154aff311c3b376fcc89dae8fccd73", size = 513878, upload-time = "2025-08-25T12:54:26.806Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/45/8c4ebc0c460e6ec38e62ab245ad3c7fc10b210116cea7c16d61602aa9558/stevedore-5.4.1-py3-none-any.whl", hash = "sha256:d10a31c7b86cba16c1f6e8d15416955fc797052351a56af15e608ad20811fcfe", size = 49533, upload-time = "2025-02-20T14:03:55.849Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c5/0c06759b95747882bb50abda18f5fb48c3e9b0fbfc6ebc0e23550b52415d/stevedore-5.5.0-py3-none-any.whl", hash = "sha256:18363d4d268181e8e8452e71a38cd77630f345b2ef6b4a8d5614dac5ee0d18cf", size = 49518, upload-time = "2025-08-25T12:54:25.445Z" },
 ]
 
 [[package]]
@@ -1883,6 +1928,21 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/78/d90f616bf5f88f8710ad067c1f8705bf7618059836ca084e5bb2a0855d75/typer-0.16.1.tar.gz", hash = "sha256:d358c65a464a7a90f338e3bb7ff0c74ac081449e53884b12ba658cbd72990614", size = 102836, upload-time = "2025-08-18T19:18:22.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/76/06dbe78f39b2203d2a47d5facc5df5102d0561e2807396471b5f7c5a30a1/typer-0.16.1-py3-none-any.whl", hash = "sha256:90ee01cb02d9b8395ae21ee3368421faf21fa138cb2a541ed369c08cec5237c9", size = 46397, upload-time = "2025-08-18T19:18:21.663Z" },
+]
+
+[[package]]
 name = "types-click"
 version = "7.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1914,11 +1974,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.1"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]
@@ -2023,6 +2083,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/4a/44d3c295350d776427904d73c189e10aeae66d7f555bb2feee16d1e4ba5a/wsproto-1.2.0.tar.gz", hash = "sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065", size = 53425, upload-time = "2022-08-23T19:58:21.447Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/58/e860788190eba3bcce367f74d29c4675466ce8dddfba85f7827588416f01/wsproto-1.2.0-py3-none-any.whl", hash = "sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736", size = 24226, upload-time = "2022-08-23T19:58:19.96Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/5e/d6e5258d69df8b4ed8c83b6664f2b47d30d2dec551a29ad72a6c69eafd31/xxhash-3.5.0.tar.gz", hash = "sha256:84f2caddf951c9cbf8dc2e22a89d4ccf5d86391ac6418fe81e3c67d0cf60b45f", size = 84241, upload-time = "2024-08-17T09:20:38.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/b8/e4b3ad92d249be5c83fa72916c9091b0965cb0faeff05d9a0a3870ae6bff/xxhash-3.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:37889a0d13b0b7d739cfc128b1c902f04e32de17b33d74b637ad42f1c55101f6", size = 31795, upload-time = "2024-08-17T09:18:46.813Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d8/b3627a0aebfbfa4c12a41e22af3742cf08c8ea84f5cc3367b5de2d039cce/xxhash-3.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:97a662338797c660178e682f3bc180277b9569a59abfb5925e8620fba00b9fc5", size = 30792, upload-time = "2024-08-17T09:18:47.862Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cc/762312960691da989c7cd0545cb120ba2a4148741c6ba458aa723c00a3f8/xxhash-3.5.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f85e0108d51092bdda90672476c7d909c04ada6923c14ff9d913c4f7dc8a3bc", size = 220950, upload-time = "2024-08-17T09:18:49.06Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e9/cc266f1042c3c13750e86a535496b58beb12bf8c50a915c336136f6168dc/xxhash-3.5.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd2fd827b0ba763ac919440042302315c564fdb797294d86e8cdd4578e3bc7f3", size = 199980, upload-time = "2024-08-17T09:18:50.445Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/85/a836cd0dc5cc20376de26b346858d0ac9656f8f730998ca4324921a010b9/xxhash-3.5.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82085c2abec437abebf457c1d12fccb30cc8b3774a0814872511f0f0562c768c", size = 428324, upload-time = "2024-08-17T09:18:51.988Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0e/15c243775342ce840b9ba34aceace06a1148fa1630cd8ca269e3223987f5/xxhash-3.5.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07fda5de378626e502b42b311b049848c2ef38784d0d67b6f30bb5008642f8eb", size = 194370, upload-time = "2024-08-17T09:18:54.164Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a1/b028bb02636dfdc190da01951d0703b3d904301ed0ef6094d948983bef0e/xxhash-3.5.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c279f0d2b34ef15f922b77966640ade58b4ccdfef1c4d94b20f2a364617a493f", size = 207911, upload-time = "2024-08-17T09:18:55.509Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d5/73c73b03fc0ac73dacf069fdf6036c9abad82de0a47549e9912c955ab449/xxhash-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:89e66ceed67b213dec5a773e2f7a9e8c58f64daeb38c7859d8815d2c89f39ad7", size = 216352, upload-time = "2024-08-17T09:18:57.073Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2a/5043dba5ddbe35b4fe6ea0a111280ad9c3d4ba477dd0f2d1fe1129bda9d0/xxhash-3.5.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bcd51708a633410737111e998ceb3b45d3dbc98c0931f743d9bb0a209033a326", size = 203410, upload-time = "2024-08-17T09:18:58.54Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b2/9a8ded888b7b190aed75b484eb5c853ddd48aa2896e7b59bbfbce442f0a1/xxhash-3.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ff2c0a34eae7df88c868be53a8dd56fbdf592109e21d4bfa092a27b0bf4a7bf", size = 210322, upload-time = "2024-08-17T09:18:59.943Z" },
+    { url = "https://files.pythonhosted.org/packages/98/62/440083fafbc917bf3e4b67c2ade621920dd905517e85631c10aac955c1d2/xxhash-3.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:4e28503dccc7d32e0b9817aa0cbfc1f45f563b2c995b7a66c4c8a0d232e840c7", size = 414725, upload-time = "2024-08-17T09:19:01.332Z" },
+    { url = "https://files.pythonhosted.org/packages/75/db/009206f7076ad60a517e016bb0058381d96a007ce3f79fa91d3010f49cc2/xxhash-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a6c50017518329ed65a9e4829154626f008916d36295b6a3ba336e2458824c8c", size = 192070, upload-time = "2024-08-17T09:19:03.007Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/6d/c61e0668943a034abc3a569cdc5aeae37d686d9da7e39cf2ed621d533e36/xxhash-3.5.0-cp313-cp313-win32.whl", hash = "sha256:53a068fe70301ec30d868ece566ac90d873e3bb059cf83c32e76012c889b8637", size = 30172, upload-time = "2024-08-17T09:19:04.355Z" },
+    { url = "https://files.pythonhosted.org/packages/96/14/8416dce965f35e3d24722cdf79361ae154fa23e2ab730e5323aa98d7919e/xxhash-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:80babcc30e7a1a484eab952d76a4f4673ff601f54d5142c26826502740e70b43", size = 30041, upload-time = "2024-08-17T09:19:05.435Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ee/518b72faa2073f5aa8e3262408d284892cb79cf2754ba0c3a5870645ef73/xxhash-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:4811336f1ce11cac89dcbd18f3a25c527c16311709a89313c3acaf771def2d4b", size = 26801, upload-time = "2024-08-17T09:19:06.547Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR enhances template error reporting to provide comprehensive context for errors in deeply nested template includes, improving debugging efficiency for complex template structures.

## Changes Made

### Template Error Formatting
- Improved error message placement - errors now appear after the "Error occurred through nested includes:" header with clear "Error: " prefix instead of being awkwardly appended to "rendering failed :"
- Added support for arbitrary levels of template nesting with full traceback through the include chain
- Enhanced context display showing the exact location in both the main template and included snippets

### Template Syntax Error Fixes
- Fixed missing `for` keyword in backend-servers snippet across multiple configuration files (deploy/base/configmap.yaml, charts/haproxy-template-ic/values.yaml)
- Preserved traceback frames for syntax errors to maintain include chain information

### Test Infrastructure Improvements
- Added current-context validation to Kind cluster fixture to prevent pykube "current context not set" errors
- Enhanced pod discovery test IP extraction with multiple fallback strategies:
  - Standard k8s pod structure (status.podIP)
  - Alternative spec.podIP location
  - Direct podIP field
  - Nested pod object structures
  - Regex-based extraction as final fallback
- Added debug logging to understand management socket response formats
- Implemented duplicate removal and localhost filtering for extracted IPs

### Code Quality Improvements (Addressing Review Feedback)

#### Test Coverage
- Added 13 comprehensive unit tests for `format_template_error` function covering:
  - Simple errors without line numbers
  - Errors with line number context
  - Deeply nested includes (3+ levels)
  - Missing snippets in include chain
  - Syntax error formatting with line context
  - Helpful hints for common errors (NoneType, undefined variables, missing filters, attributes)
  - Two-level includes
  - Edge cases (empty templates, invalid line numbers, long error messages)
- Added 6 tests for `_extract_snippet_name` helper function
- Added 6 tests for `_get_context_lines` helper function
- **Coverage improved from ~91% to ~95%** for the templating module

#### Performance Optimizations
- Added `MAX_FRAMES` limit (10) to prevent excessive traceback traversal
- Early termination when sufficient template frames are found
- Reduced string operations by consolidating duplicate logic

#### Code Refactoring
- Extracted common functionality into reusable helper functions:
  - `_format_snippet_context`: Formats context for snippets with appropriate headers
  - `_process_include_chain`: Processes the entire include chain to build error context
- Eliminated code duplication between 2-level and 3+ level include handling
- Improved maintainability and testability of error formatting logic

#### Input Validation
- Added type checking for `content_to_analyze` before string operations
- Graceful handling of non-string content types
- Protected against malformed include statements

## Technical Details

The error reporting system now properly handles:
- Single-level errors with line numbers and context
- Two-level includes (main template → snippet)
- Deep nesting with multiple include levels (main → snippet1 → snippet2 → ...)
- Syntax errors preserving the full include chain

The pod discovery test improvements ensure more robust IP extraction from various response formats, making tests more reliable across different environments.

## Testing

- All existing tests continue to pass
- Template error formatting correctly displays nested include chains
- Pod discovery tests handle various response structures
- Full test suite passes (758 tests) with improved coverage