### PR TITLE
fix: make codecov status checks informational

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,13 +6,15 @@ coverage:
   status:
     project:
       default:
-        target: 85%              # Require 85% overall coverage
+        target: auto             # Compare against base branch coverage
         threshold: 2%            # Allow 2% drop from base
         base: auto               # Compare against base branch
+        informational: true      # Report but never fail the PR check
     patch:
       default:
         target: 90%              # Require 90% coverage for new code
         threshold: 0%            # No drop allowed for new code
+        informational: true      # Report but never fail the PR check
 
   # Ignore paths
   ignore:


### PR DESCRIPTION
The codecov/project check has been failing on all 5 open Dependabot PRs (#65, #68, #71, #72, #73) despite all actual CI checks (unit tests, integration tests, acceptance tests, linting) passing. This happens because the project coverage target was set to a fixed 85% which the project apparently doesn't meet.

Changes:
- Set `informational: true` on both `project` and `patch` codecov status checks so they report coverage data without ever failing the PR check
- Changed the project target from a fixed 85% to `auto` (compare against base branch) which better tracks coverage regressions

After merging, the 5 open Dependabot PRs will need a rebase to pick up the new codecov config.