### PR TITLE
fix: stabilize flaky debouncer error handling test

### DIFF
--- a/tests/unit/operator/test_debouncer.py
+++ b/tests/unit/operator/test_debouncer.py
@@ -149,19 +149,13 @@ async def test_render_error_handling(mock_render_haproxy_templates):
     # Configure the mock to raise an exception using helper
     mock_render_haproxy_templates.side_effect = Exception("Test error")
 
-    debouncer = create_debouncer(MIN_INTERVAL_SHORT, MIN_INTERVAL_LONG)
-
-    await debouncer.start()
-
-    try:
+    async with managed_debouncer(MIN_INTERVAL_SHORT, MIN_INTERVAL_LONG) as debouncer:
         # Trigger rendering
         await debouncer.trigger()
-        await asyncio.sleep(SLEEP_SHORT)
+        await asyncio.sleep(SLEEP_LONG)
 
         # Should have attempted render despite error
         assert mock_render_haproxy_templates.call_count >= 1
-    finally:
-        await debouncer.stop()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The test_render_error_handling test in test_debouncer.py was flaky on CI runners due to tight async timing constraints. It used manual start/stop lifecycle and a short sleep (80ms) that was insufficient under load, causing the background task to not complete rendering before the assertion. This was the root cause of the CI failure on the dependabot/uv/deepdiff-8.6.1 branch.

Switched to managed_debouncer context manager for consistent lifecycle management (matching other debouncer tests) and increased the sleep to SLEEP_LONG (250ms) to give the async background task sufficient time on loaded CI runners.